### PR TITLE
Add new GcMetric `GC/ParNew` and `GC/ConcurrentMarkSweep`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added new GcMetric `GC/ParNew` and `GC/ConcurrentMarkSweep` 
+
 # 3.1.0 (23.02.2018)
 - Added support for New Relic Browser conditions 
 

--- a/newrelic-alerts-configurator/README.md
+++ b/newrelic-alerts-configurator/README.md
@@ -183,7 +183,9 @@ What you can set for APM JVM metric condition:
     - Garbage collection CPU time
 - gc metric - Metric used to get GC CPU time. To use it metric has to be set to measure garbage collection CPU time. Possible values are:
     - PS MarkSweep
-    - PS Scavenge   
+    - PS Scavenge
+    - ParNew
+    - ConcurrentMarkSweep
 - run book url (optional) - The runbook URL to display in notifications.
 - terms - Collection of [terms](#term) used for alerts condition.
 - violation close timer - Duration (in hours) after which instance-based violations will automatically close.

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/ApmJvmCondition.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/ApmJvmCondition.java
@@ -95,7 +95,9 @@ public class ApmJvmCondition implements Condition {
 
     public enum GcMetric {
         GC_MARK_SWEEP("GC/PS MarkSweep"),
-        GC_SCAVENGE("GC/PS Scavenge");
+        GC_SCAVENGE("GC/PS Scavenge"),
+        GC_PAR_NEW("GC/ParNew"),
+        GC_CONCURRENT_MARK_SWEEP("GC/ConcurrentMarkSweep");
 
         private String metricData;
 


### PR DESCRIPTION
New enum entries added as per article:[Garbage collection CPU time alert](https://discuss.newrelic.com/t/garbage-collection-cpu-time-alert/27964).