### PR TITLE
Custom deserializer for incude_json_attachment field

### DIFF
--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/channels/AlertsChannelConfiguration.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/channels/AlertsChannelConfiguration.java
@@ -1,6 +1,7 @@
 package com.ocadotechnology.newrelic.apiclient.model.channels;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -19,6 +20,7 @@ public class AlertsChannelConfiguration {
     String channel;
     @JsonProperty
     String url;
+    @JsonDeserialize(using = IncludeJsonAttachmentDeserializer.class)
     @JsonProperty("include_json_attachment")
     Boolean includeJsonAttachment;
     @JsonProperty

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializer.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializer.java
@@ -14,16 +14,16 @@ import java.util.Set;
 
 public class IncludeJsonAttachmentDeserializer extends JsonDeserializer<Boolean> {
 
-    private static Set<String> THRUTHY_VALUES = new HashSet<>(Arrays.asList("1", "true"));
-    private static Set<String> FALSY_VALUES = new HashSet<>(Arrays.asList("0", "false"));
+    private static final Set<String> TRUTHY_VALUES = new HashSet<>(Arrays.asList("1", "true"));
+    private static final Set<String> FALSY_VALUES = new HashSet<>(Arrays.asList("0", "false"));
 
     @Override
-    public Boolean deserialize(final JsonParser jsonParser, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
-        final String value = jsonParser.readValueAs(String.class);
+    public Boolean deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        String value = jsonParser.readValueAs(String.class);
 
         return Optional.ofNullable(StringUtils.trimToNull(value))
                 .map(val -> {
-                    if (THRUTHY_VALUES.contains(val)) {
+                    if (TRUTHY_VALUES.contains(val)) {
                         return true;
                     }
                     if (FALSY_VALUES.contains(val)) {

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializer.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializer.java
@@ -1,0 +1,35 @@
+package com.ocadotechnology.newrelic.apiclient.model.channels;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class IncludeJsonAttachmentDeserializer extends JsonDeserializer<Boolean> {
+
+    private static Set<String> THRUTHY_VALUES = new HashSet<>(Arrays.asList("1", "true"));
+    private static Set<String> FALSY_VALUES = new HashSet<>(Arrays.asList("0", "false"));
+
+    @Override
+    public Boolean deserialize(final JsonParser jsonParser, final DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        final String value = jsonParser.readValueAs(String.class);
+
+        return Optional.ofNullable(StringUtils.trimToNull(value))
+                .map(val -> {
+                    if (THRUTHY_VALUES.contains(val)) {
+                        return true;
+                    }
+                    if (FALSY_VALUES.contains(val)) {
+                        return false;
+                    }
+                    throw new RuntimeException("Unsupported field value: " + val);
+                }).orElse(null);
+    }
+}

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializerTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializerTest.java
@@ -27,10 +27,10 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToTrue_whenTrueProvided() throws IOException {
 
         // given
-        final String sampleJsonValue = "{ \"sampleField\" : true }";
+        String sampleJsonValue = "{ \"sampleField\" : true }";
 
         // when
-        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+        SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
 
         //then
         assertThat(sampleJson.sampleField).isTrue();
@@ -40,10 +40,10 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToFalse_whenFalseProvided() throws IOException {
 
         // given
-        final String sampleJsonValue = "{ \"sampleField\" : false }";
+        String sampleJsonValue = "{ \"sampleField\" : false }";
 
         // when
-        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+        SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
 
         //then
         assertThat(sampleJson.sampleField).isFalse();
@@ -53,10 +53,10 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToTrue_whenTrueStringProvided() throws IOException {
 
         // given
-        final String sampleJsonValue = "{ \"sampleField\" : \"true\" }";
+        String sampleJsonValue = "{ \"sampleField\" : \"true\" }";
 
         // when
-        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+        SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
 
         //then
         assertThat(sampleJson.sampleField).isTrue();
@@ -66,10 +66,10 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToFalse_whenFalseStringProvided() throws IOException {
 
         // given
-        final String sampleJsonValue = "{ \"sampleField\" : \"false\" }";
+        String sampleJsonValue = "{ \"sampleField\" : \"false\" }";
 
         // when
-        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+        SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
 
         //then
         assertThat(sampleJson.sampleField).isFalse();
@@ -79,10 +79,10 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToTrue_when1StringProvided() throws IOException {
 
         // given
-        final String sampleJsonValue = "{ \"sampleField\" : \"1\" }";
+        String sampleJsonValue = "{ \"sampleField\" : \"1\" }";
 
         // when
-        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+        SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
 
         //then
         assertThat(sampleJson.sampleField).isTrue();
@@ -92,10 +92,10 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToFalse_when0StringProvided() throws IOException {
 
         // given
-        final String sampleJsonValue = "{ \"sampleField\" : \"0\" }";
+        String sampleJsonValue = "{ \"sampleField\" : \"0\" }";
 
         // when
-        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+        SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
 
         //then
         assertThat(sampleJson.sampleField).isFalse();
@@ -104,10 +104,10 @@ public class IncludeJsonAttachmentDeserializerTest {
     @Test
     public void deserialize_shouldDeserializeToNull_whenEmptyStringProvided() throws IOException {
         // given
-        final String sampleJsonValue = "{ \"sampleField\" : \"\" }";
+        String sampleJsonValue = "{ \"sampleField\" : \"\" }";
 
         // when
-        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+        SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
 
         //then
         assertThat(sampleJson.sampleField).isNull();
@@ -116,10 +116,10 @@ public class IncludeJsonAttachmentDeserializerTest {
     @Test
     public void deserialize_shouldDeserializeToNull_whenNoValueProvided() throws IOException {
         // given
-        final String sampleJsonValue = "{ }";
+        String sampleJsonValue = "{ }";
 
         // when
-        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+        SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
 
         //then
         assertThat(sampleJson.sampleField).isNull();
@@ -128,10 +128,10 @@ public class IncludeJsonAttachmentDeserializerTest {
     @Test
     public void deserialize_shouldDeserializeToNull_whenNullProvided() throws IOException {
         // given
-        final String sampleJsonValue = "{ \"sampleField\" : null }";
+        String sampleJsonValue = "{ \"sampleField\" : null }";
 
         // when
-        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+        SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
 
         //then
         assertThat(sampleJson.sampleField).isNull();
@@ -143,7 +143,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     @Test
     public void deserialize_shouldThrowException_unknownValueProvided() throws IOException {
         // given
-        final String sampleJsonValue = "{ \"sampleField\" : \"some-unknown-value\" }";
+        String sampleJsonValue = "{ \"sampleField\" : \"some-unknown-value\" }";
 
         // then
         expectedException.expect(JsonMappingException.class);

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializerTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializerTest.java
@@ -21,13 +21,13 @@ public class IncludeJsonAttachmentDeserializerTest {
         public Boolean sampleField;
     }
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     public void deserialize_shouldDeserializeToTrue_whenTrueProvided() throws IOException {
 
         // given
-        String sampleJsonValue = "{ \"sampleField\" : true }";
+        final String sampleJsonValue = "{ \"sampleField\" : true }";
 
         // when
         final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
@@ -40,7 +40,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToFalse_whenFalseProvided() throws IOException {
 
         // given
-        String sampleJsonValue = "{ \"sampleField\" : false }";
+        final String sampleJsonValue = "{ \"sampleField\" : false }";
 
         // when
         final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
@@ -53,7 +53,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToTrue_whenTrueStringProvided() throws IOException {
 
         // given
-        String sampleJsonValue = "{ \"sampleField\" : \"true\" }";
+        final String sampleJsonValue = "{ \"sampleField\" : \"true\" }";
 
         // when
         final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
@@ -66,7 +66,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToFalse_whenFalseStringProvided() throws IOException {
 
         // given
-        String sampleJsonValue = "{ \"sampleField\" : \"false\" }";
+        final String sampleJsonValue = "{ \"sampleField\" : \"false\" }";
 
         // when
         final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
@@ -79,7 +79,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToTrue_when1StringProvided() throws IOException {
 
         // given
-        String sampleJsonValue = "{ \"sampleField\" : \"1\" }";
+        final String sampleJsonValue = "{ \"sampleField\" : \"1\" }";
 
         // when
         final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
@@ -92,7 +92,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     public void deserialize_shouldDeserializeToFalse_when0StringProvided() throws IOException {
 
         // given
-        String sampleJsonValue = "{ \"sampleField\" : \"0\" }";
+        final String sampleJsonValue = "{ \"sampleField\" : \"0\" }";
 
         // when
         final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
@@ -104,7 +104,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     @Test
     public void deserialize_shouldDeserializeToNull_whenEmptyStringProvided() throws IOException {
         // given
-        String sampleJsonValue = "{ \"sampleField\" : \"\" }";
+        final String sampleJsonValue = "{ \"sampleField\" : \"\" }";
 
         // when
         final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
@@ -116,7 +116,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     @Test
     public void deserialize_shouldDeserializeToNull_whenNoValueProvided() throws IOException {
         // given
-        String sampleJsonValue = "{ }";
+        final String sampleJsonValue = "{ }";
 
         // when
         final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
@@ -128,7 +128,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     @Test
     public void deserialize_shouldDeserializeToNull_whenNullProvided() throws IOException {
         // given
-        String sampleJsonValue = "{ \"sampleField\" : null }";
+        final String sampleJsonValue = "{ \"sampleField\" : null }";
 
         // when
         final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
@@ -143,7 +143,7 @@ public class IncludeJsonAttachmentDeserializerTest {
     @Test
     public void deserialize_shouldThrowException_unknownValueProvided() throws IOException {
         // given
-        String sampleJsonValue = "{ \"sampleField\" : \"some-unknown-value\" }";
+        final String sampleJsonValue = "{ \"sampleField\" : \"some-unknown-value\" }";
 
         // then
         expectedException.expect(JsonMappingException.class);

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializerTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/model/channels/IncludeJsonAttachmentDeserializerTest.java
@@ -1,0 +1,155 @@
+package com.ocadotechnology.newrelic.apiclient.model.channels;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
+
+public class IncludeJsonAttachmentDeserializerTest {
+
+    public static class SampleJson {
+
+        @JsonDeserialize(using = IncludeJsonAttachmentDeserializer.class)
+        public Boolean sampleField;
+    }
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void deserialize_shouldDeserializeToTrue_whenTrueProvided() throws IOException {
+
+        // given
+        String sampleJsonValue = "{ \"sampleField\" : true }";
+
+        // when
+        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+
+        //then
+        assertThat(sampleJson.sampleField).isTrue();
+    }
+
+    @Test
+    public void deserialize_shouldDeserializeToFalse_whenFalseProvided() throws IOException {
+
+        // given
+        String sampleJsonValue = "{ \"sampleField\" : false }";
+
+        // when
+        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+
+        //then
+        assertThat(sampleJson.sampleField).isFalse();
+    }
+
+    @Test
+    public void deserialize_shouldDeserializeToTrue_whenTrueStringProvided() throws IOException {
+
+        // given
+        String sampleJsonValue = "{ \"sampleField\" : \"true\" }";
+
+        // when
+        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+
+        //then
+        assertThat(sampleJson.sampleField).isTrue();
+    }
+
+    @Test
+    public void deserialize_shouldDeserializeToFalse_whenFalseStringProvided() throws IOException {
+
+        // given
+        String sampleJsonValue = "{ \"sampleField\" : \"false\" }";
+
+        // when
+        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+
+        //then
+        assertThat(sampleJson.sampleField).isFalse();
+    }
+
+    @Test
+    public void deserialize_shouldDeserializeToTrue_when1StringProvided() throws IOException {
+
+        // given
+        String sampleJsonValue = "{ \"sampleField\" : \"1\" }";
+
+        // when
+        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+
+        //then
+        assertThat(sampleJson.sampleField).isTrue();
+    }
+
+    @Test
+    public void deserialize_shouldDeserializeToFalse_when0StringProvided() throws IOException {
+
+        // given
+        String sampleJsonValue = "{ \"sampleField\" : \"0\" }";
+
+        // when
+        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+
+        //then
+        assertThat(sampleJson.sampleField).isFalse();
+    }
+
+    @Test
+    public void deserialize_shouldDeserializeToNull_whenEmptyStringProvided() throws IOException {
+        // given
+        String sampleJsonValue = "{ \"sampleField\" : \"\" }";
+
+        // when
+        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+
+        //then
+        assertThat(sampleJson.sampleField).isNull();
+    }
+
+    @Test
+    public void deserialize_shouldDeserializeToNull_whenNoValueProvided() throws IOException {
+        // given
+        String sampleJsonValue = "{ }";
+
+        // when
+        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+
+        //then
+        assertThat(sampleJson.sampleField).isNull();
+    }
+
+    @Test
+    public void deserialize_shouldDeserializeToNull_whenNullProvided() throws IOException {
+        // given
+        String sampleJsonValue = "{ \"sampleField\" : null }";
+
+        // when
+        final SampleJson sampleJson = objectMapper.readValue(sampleJsonValue, SampleJson.class);
+
+        //then
+        assertThat(sampleJson.sampleField).isNull();
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void deserialize_shouldThrowException_unknownValueProvided() throws IOException {
+        // given
+        String sampleJsonValue = "{ \"sampleField\" : \"some-unknown-value\" }";
+
+        // then
+        expectedException.expect(JsonMappingException.class);
+        expectedException.expect(hasMessage(containsString("Unsupported field value: some-unknown-value")));
+
+        // when
+        objectMapper.readValue(sampleJsonValue, SampleJson.class);
+    }
+}


### PR DESCRIPTION
Custom deserializer for incude_json_attachment field from AlertsChannelConfiguration - this fix problem with deserializing alerts channels when new relic return \"1\" instead of boolean.