### PR TITLE
Add MarkSweepCompact and Copy to GcMetric enum

### DIFF
--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/ApmJvmCondition.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/ApmJvmCondition.java
@@ -97,8 +97,9 @@ public class ApmJvmCondition implements Condition {
         GC_MARK_SWEEP("GC/PS MarkSweep"),
         GC_SCAVENGE("GC/PS Scavenge"),
         GC_PAR_NEW("GC/ParNew"),
-        GC_CONCURRENT_MARK_SWEEP("GC/MarkSweepCompact"),
-        GC_CONCURRENT_MARK_SWEEP("GC/Copy");
+        GC_CONCURRENT_MARK_SWEEP("GC/ConcurrentMarkSweep"),
+        GC_MARK_SWEEP_COMPACT("GC/MarkSweepCompact"),
+        GC_COPY("GC/Copy");
 
         private String metricData;
 

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/ApmJvmCondition.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/ApmJvmCondition.java
@@ -97,7 +97,8 @@ public class ApmJvmCondition implements Condition {
         GC_MARK_SWEEP("GC/PS MarkSweep"),
         GC_SCAVENGE("GC/PS Scavenge"),
         GC_PAR_NEW("GC/ParNew"),
-        GC_CONCURRENT_MARK_SWEEP("GC/ConcurrentMarkSweep");
+        GC_CONCURRENT_MARK_SWEEP("GC/MarkSweepCompact"),
+        GC_CONCURRENT_MARK_SWEEP("GC/Copy");
 
         private String metricData;
 


### PR DESCRIPTION
Copy and MarkSweepCompact are two newer Garbage Collectors for Young/Old respectively. Many of osp's java 11 apps are using these garbage collectors, so this change is to extend the current enum of GcMetrics to include the metric names for these garbage collectors too.