### PR TITLE
Add support for Dashboard API

### DIFF
--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/DashboardsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/DashboardsApi.java
@@ -1,0 +1,57 @@
+package com.ocadotechnology.newrelic.apiclient;
+
+import com.ocadotechnology.newrelic.apiclient.model.dashboards.Dashboard;
+
+import java.util.List;
+
+/**
+ * See <a href="https://docs.newrelic.com/docs/insights/insights-api/manage-dashboards/insights-dashboard-api">Doc</a>
+ */
+public interface DashboardsApi {
+
+    /**
+     * View a list of {@link Dashboard}. The list shows dashboard metadata only; no widgets will appear in the list.
+     *
+     * @param dashboardTitle name of the dashboard(s) registered in NewRelic. This may be a partial name.
+     * @return List containing {@link Dashboard} objects, or empty if no dashboard including dashboardTitle exist.
+     * This
+     */
+    List<Dashboard> getByTitle(String dashboardTitle);
+
+    /**
+     * View an existing {@link Dashboard} and all accessible widgets for the dashboard id.
+     *
+     * @param dashboardId id of the dashboard registered in NewRelic
+     * @return found {@link Dashboard}
+     */
+    Dashboard getById(int dashboardId);
+
+    /**
+     * Create a new {@link Dashboard}.
+     * <p>
+     * The API permits a maximum of 300 widgets when creating or updating a dashboard. Attempting to POST more than 300 widgets will produce an error.
+     *
+     * @param dashboard to be created in NewRelic
+     * @return created {@link Dashboard}
+     */
+    Dashboard create(Dashboard dashboard);
+
+    /**
+     * Update an existing {@link Dashboard} for the dashboard id.
+     * <p>
+     * The API permits a maximum of 300 widgets when creating or updating a dashboard. Attempting to PUT more than 300 widgets will produce an error.
+     *
+     * @param dashboard to be updated in NewRelic
+     * @return updated {@link Dashboard}
+     */
+    Dashboard update(Dashboard dashboard);
+
+    /**
+     * Delete an existing {@link Dashboard} indicated by the dashboard id.
+     *
+     * @param dashboardId of the dashboard to be deleted
+     * @return deleted {@link Dashboard}
+     */
+    Dashboard delete(int dashboardId);
+
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/NewRelicApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/NewRelicApi.java
@@ -2,10 +2,9 @@ package com.ocadotechnology.newrelic.apiclient;
 
 import com.ocadotechnology.newrelic.apiclient.internal.NewRelicInternalApi;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.AlertsCondition;
-import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.external.AlertsExternalServiceCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.synthetics.AlertsSyntheticsCondition;
-
 import lombok.Getter;
 
 /**
@@ -39,6 +38,8 @@ public class NewRelicApi {
 
     private final UsersApi usersApi;
 
+    private final DashboardsApi dashboardsApi;
+
     private final SyntheticsMonitorsApi syntheticsMonitorsApi;
 
     /**
@@ -70,6 +71,7 @@ public class NewRelicApi {
         deploymentsApi = internalApi.getDeploymentsApi();
         serversApi = internalApi.getServersApi();
         usersApi = internalApi.getUsersApi();
+        dashboardsApi = internalApi.getDashboardsApi();
         syntheticsMonitorsApi = internalApi.getSyntheticsMonitorsApi();
     }
 }

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDashboardsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDashboardsApi.java
@@ -1,0 +1,77 @@
+package com.ocadotechnology.newrelic.apiclient.internal;
+
+
+import com.ocadotechnology.newrelic.apiclient.DashboardsApi;
+import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClient;
+import com.ocadotechnology.newrelic.apiclient.internal.model.DashboardList;
+import com.ocadotechnology.newrelic.apiclient.internal.model.DashboardWrapper;
+import com.ocadotechnology.newrelic.apiclient.model.dashboards.Dashboard;
+import org.glassfish.jersey.uri.UriComponent;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static org.glassfish.jersey.uri.UriComponent.Type.QUERY_PARAM_SPACE_ENCODED;
+
+class DefaultDashboardsApi extends ApiBase implements DashboardsApi {
+
+    private static final String DASHBOARDS_URL = "/v2/dashboards.json";
+
+    private static final String DASHBOARD_URL = "/v2/dashboards/{dashboard_id}.json";
+
+    DefaultDashboardsApi(NewRelicClient client) {
+        super(client);
+    }
+
+    @Override
+    public Dashboard getById(int dashboardId) {
+        return client
+                .target(DASHBOARD_URL)
+                .resolveTemplate("dashboard_id", dashboardId)
+                .request(APPLICATION_JSON_TYPE)
+                .get(DashboardWrapper.class)
+                .getDashboard();
+    }
+
+    @Override
+    public List<Dashboard> getByTitle(String dashboardTitle) {
+        String dashboardTitleEncoded = UriComponent.encode(dashboardTitle, QUERY_PARAM_SPACE_ENCODED);
+        Invocation.Builder builder = client
+                .target(DASHBOARDS_URL)
+                .queryParam("filter[title]", dashboardTitleEncoded)
+                .request(APPLICATION_JSON_TYPE);
+        return getPageable(builder, DashboardList.class)
+                .getList();
+    }
+
+    @Override
+    public Dashboard create(Dashboard dashboard) {
+        return client
+                .target(DASHBOARDS_URL)
+                .request(APPLICATION_JSON_TYPE)
+                .post(Entity.entity(new DashboardWrapper(dashboard), APPLICATION_JSON_TYPE), DashboardWrapper.class)
+                .getDashboard();
+    }
+
+    @Override
+    public Dashboard update(Dashboard dashboard) {
+        return client
+                .target(DASHBOARD_URL)
+                .resolveTemplate("dashboard_id", dashboard.getId())
+                .request(APPLICATION_JSON_TYPE)
+                .put(Entity.entity(new DashboardWrapper(dashboard), APPLICATION_JSON_TYPE), DashboardWrapper.class)
+                .getDashboard();
+    }
+
+    @Override
+    public Dashboard delete(int dashboardId) {
+        return client
+                .target(DASHBOARD_URL)
+                .resolveTemplate("dashboard_id", dashboardId)
+                .request(APPLICATION_JSON_TYPE)
+                .delete(DashboardWrapper.class)
+                .getDashboard();
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/NewRelicInternalApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/NewRelicInternalApi.java
@@ -3,10 +3,9 @@ package com.ocadotechnology.newrelic.apiclient.internal;
 import com.ocadotechnology.newrelic.apiclient.*;
 import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClient;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.AlertsCondition;
-import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.external.AlertsExternalServiceCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.synthetics.AlertsSyntheticsCondition;
-
 import lombok.Getter;
 
 /**
@@ -39,12 +38,14 @@ public class NewRelicInternalApi {
 
     private final SyntheticsMonitorsApi syntheticsMonitorsApi;
 
+    private final DashboardsApi dashboardsApi;
+
     /**
      * NewRelic API constructor.
      *
-     * @param restApiUrl NewRelic REST API URL, for example https://api.newrelic.com
+     * @param restApiUrl       NewRelic REST API URL, for example https://api.newrelic.com
      * @param syntheticsApiUrl NewRelic Synthetics API URL
-     * @param apiKey  API Key for given NewRelic account
+     * @param apiKey           API Key for given NewRelic account
      */
     public NewRelicInternalApi(String restApiUrl, String syntheticsApiUrl, String apiKey) {
         NewRelicClient client = new NewRelicClient(restApiUrl, apiKey);
@@ -59,6 +60,7 @@ public class NewRelicInternalApi {
         deploymentsApi = new DefaultDeploymentsApi(client);
         serversApi = new DefaultServersApi(client);
         usersApi = new DefaultUsersApi(client);
+        dashboardsApi = new DefaultDashboardsApi(client);
 
         NewRelicClient syntheticsClient = new NewRelicClient(syntheticsApiUrl, apiKey);
         syntheticsMonitorsApi = new DefaultSyntheticsMonitorsApi(syntheticsClient);

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/model/DashboardList.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/model/DashboardList.java
@@ -1,0 +1,16 @@
+package com.ocadotechnology.newrelic.apiclient.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ocadotechnology.newrelic.apiclient.model.dashboards.Dashboard;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+public class DashboardList extends ObjectList<Dashboard, DashboardList> {
+    @JsonCreator
+    public DashboardList(@JsonProperty("dashboards") List<Dashboard> items) {
+        super(items, DashboardList::new);
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/model/DashboardWrapper.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/model/DashboardWrapper.java
@@ -1,0 +1,11 @@
+package com.ocadotechnology.newrelic.apiclient.internal.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ocadotechnology.newrelic.apiclient.model.dashboards.Dashboard;
+import lombok.Value;
+
+@Value
+public class DashboardWrapper {
+    @JsonProperty
+    Dashboard dashboard;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/Dashboard.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/Dashboard.java
@@ -1,0 +1,41 @@
+package com.ocadotechnology.newrelic.apiclient.model.dashboards;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ocadotechnology.newrelic.apiclient.model.dashboards.dashboard.DashboardMetadata;
+import com.ocadotechnology.newrelic.apiclient.model.dashboards.widget.Widget;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+/**
+ * See <a href="https://docs.newrelic.com/docs/insights/insights-api/manage-dashboards/insights-dashboard-api#schema">Doc</a>
+ */
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class Dashboard {
+    @JsonProperty
+    Integer id;
+    @JsonProperty
+    String title;
+    @JsonProperty
+    String description;
+    @JsonProperty
+    String icon;
+    @JsonProperty
+    String visibility;
+    @JsonProperty
+    String editable;
+    @JsonProperty("ui_url")
+    String uiUrl;
+    @JsonProperty("api_url")
+    String apiUrl;
+    @JsonProperty("owner_email")
+    String ownerEmail;
+    @JsonProperty
+    DashboardMetadata metadata;
+    @JsonProperty
+    List<Widget> widgets;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/dashboard/DashboardMetadata.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/dashboard/DashboardMetadata.java
@@ -1,0 +1,15 @@
+package com.ocadotechnology.newrelic.apiclient.model.dashboards.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class DashboardMetadata {
+
+    @JsonProperty
+    Integer version;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/widget/Widget.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/widget/Widget.java
@@ -1,0 +1,29 @@
+package com.ocadotechnology.newrelic.apiclient.model.dashboards.widget;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+/**
+ * See <a href="https://docs.newrelic.com/docs/insights/insights-api/manage-dashboards/insights-dashboard-api#widget-data">Doc</a>
+ */
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class Widget {
+    @JsonProperty("widget_id")
+    Integer widgetId;
+    @JsonProperty("account_id")
+    Integer accountId;
+    @JsonProperty
+    String visualization;
+    @JsonProperty
+    WidgetLayout layout;
+    @JsonProperty
+    List<WidgetData> data;
+    @JsonProperty
+    WidgetPresentation presentation;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/widget/WidgetData.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/widget/WidgetData.java
@@ -1,0 +1,14 @@
+package com.ocadotechnology.newrelic.apiclient.model.dashboards.widget;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class WidgetData {
+    @JsonProperty
+    String nrql;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/widget/WidgetLayout.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/widget/WidgetLayout.java
@@ -1,0 +1,20 @@
+package com.ocadotechnology.newrelic.apiclient.model.dashboards.widget;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class WidgetLayout {
+    @JsonProperty
+    Integer width;
+    @JsonProperty
+    Integer height;
+    @JsonProperty
+    Integer row;
+    @JsonProperty
+    Integer column;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/widget/WidgetPresentation.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/dashboards/widget/WidgetPresentation.java
@@ -1,0 +1,16 @@
+package com.ocadotechnology.newrelic.apiclient.model.dashboards.widget;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class WidgetPresentation {
+    @JsonProperty
+    String title;
+    @JsonProperty
+    String notes;
+}

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDashboardsApiTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDashboardsApiTest.java
@@ -1,0 +1,81 @@
+package com.ocadotechnology.newrelic.apiclient.internal;
+
+import com.ocadotechnology.newrelic.apiclient.DashboardsApi;
+import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClient;
+import com.ocadotechnology.newrelic.apiclient.internal.model.DashboardList;
+import com.ocadotechnology.newrelic.apiclient.model.dashboards.Dashboard;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultDashboardsApiTest {
+
+    private static final String DASHBOARD_FILTER_VALUE = "dashboard";
+
+    @Mock
+    private Response responseMock;
+
+    private DashboardsApi testee;
+
+    @Before
+    public void setUp() {
+        NewRelicClient clientMock = mock(NewRelicClient.class);
+        WebTarget webTargetMock = mock(WebTarget.class);
+        Invocation.Builder builderMock = mock(Invocation.Builder.class);
+
+        when(clientMock.target("/v2/dashboards.json")).thenReturn(webTargetMock);
+        when(webTargetMock.queryParam("filter[title]", DASHBOARD_FILTER_VALUE)).thenReturn(webTargetMock);
+        when(webTargetMock.request(APPLICATION_JSON_TYPE)).thenReturn(builderMock);
+        when(builderMock.get()).thenReturn(responseMock);
+
+        testee = new DefaultDashboardsApi(clientMock);
+    }
+
+    @Test
+    public void getByTitle_shouldReturnDashboards_whenClientReturnsNotUniqueResult() {
+        when(responseMock.readEntity(DashboardList.class)).thenReturn(new DashboardList(asList(
+                Dashboard.builder().title(DASHBOARD_FILTER_VALUE).build(),
+                Dashboard.builder().title("dashboard1").build()
+        )));
+
+        List<Dashboard> dashboard = testee.getByTitle(DASHBOARD_FILTER_VALUE);
+
+        assertThat(dashboard).isNotEmpty();
+        assertThat(dashboard).hasSize(2);
+    }
+
+    @Test
+    public void getByTitle_shouldReturnDashboard_whenClientReturnsResultContainingQueriedTitle() {
+        when(responseMock.readEntity(DashboardList.class)).thenReturn(new DashboardList(Collections.singletonList(
+                Dashboard.builder().title("dashboard1").build()
+        )));
+
+        List<Dashboard> dashboard = testee.getByTitle(DASHBOARD_FILTER_VALUE);
+
+        assertThat(dashboard).isNotEmpty();
+    }
+
+    @Test
+    public void getByTitle_shouldNotReturnDashboard_whenClientReturnsEmptyList() {
+        when(responseMock.readEntity(DashboardList.class)).thenReturn(new DashboardList(Collections.emptyList()));
+
+        List<Dashboard> dashboard = testee.getByTitle(DASHBOARD_FILTER_VALUE);
+
+        assertThat(dashboard).isEmpty();
+    }
+}


### PR DESCRIPTION
This Pull Request introduces a possibility to find, create, update, delete Insights Dashboards via NewRelic API.

Note: I know that it's not quite related to the project name (alerts-configurator), however I haven't found better place to introduce such additional feature.