### PR TITLE
Add support for NRQL Signal configuration

### DIFF
--- a/newrelic-alerts-configurator/README.md
+++ b/newrelic-alerts-configurator/README.md
@@ -398,7 +398,17 @@ What you can set for NRQL condition:
     - 30
     - 60
     - 120
-
+- signal configuration - Determines how data should be collected and what should happened when there is lack of data:
+    - aggregation window - Time (in seconds) for how long NewRelic collects data before running the NRQL query.
+    - evaluation windows - Number of windows to evaluate data.
+    - signal fill option - Configuration of filling data gaps/signal lost. Possible values are:
+        - NONE - do not fill any data
+        - LAST_KNOWN_VALUE - fill with last known value
+    - signal lost configuration:
+        - signal is lost after - Time (in seconds) for the signal treated as lost.
+        - open new violation on signal lost - Opens a loss of signal violation when no signal.
+        - closeCurrentViolationsOnSignalLost - cCoses all currently open violations when no signal is heard.
+     
 Example NRQL condition configuration:
 
 ```java

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfigurator.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfigurator.java
@@ -3,6 +3,7 @@ package com.ocadotechnology.newrelic.alertsconfigurator;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.PolicyConfiguration;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.NrqlCondition;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.ExpirationUtils;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.NrqlSignalConfiguration;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.SignalUtils;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.TermsUtils;
 import com.ocadotechnology.newrelic.apiclient.NewRelicApi;
@@ -45,11 +46,12 @@ class NrqlConditionConfigurator extends AbstractPolicyItemConfigurator<AlertsNrq
                 .query(condition.getQuery())
                 .build());
 
-        condition.getSignal()
-            .ifPresent(nrqlSignalConfiguration -> nrqlConditionBuilder
+        NrqlSignalConfiguration nrqlSignalConfiguration = condition.getSignal();
+        if (nrqlSignalConfiguration != null) {
+            nrqlConditionBuilder
                 .signal(SignalUtils.createSignal(nrqlSignalConfiguration))
-                .expiration(ExpirationUtils.createExpiration(nrqlSignalConfiguration.getSignalLostConfiguration()))
-            );
+                .expiration(ExpirationUtils.createExpiration(nrqlSignalConfiguration.getSignalLostConfiguration()));
+        }
 
         return nrqlConditionBuilder.build();
     }

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfigurator.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfigurator.java
@@ -1,20 +1,19 @@
 package com.ocadotechnology.newrelic.alertsconfigurator;
 
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.PolicyConfiguration;
-
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.NrqlCondition;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.ExpirationUtils;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.SignalUtils;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.TermsUtils;
 import com.ocadotechnology.newrelic.apiclient.NewRelicApi;
-
 import com.ocadotechnology.newrelic.apiclient.PolicyItemApi;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.Nrql;
+import java.util.Collection;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-
-import java.util.Collection;
-import java.util.Optional;
 
 @Slf4j
 class NrqlConditionConfigurator extends AbstractPolicyItemConfigurator<AlertsNrqlCondition, NrqlCondition> {
@@ -35,17 +34,24 @@ class NrqlConditionConfigurator extends AbstractPolicyItemConfigurator<AlertsNrq
 
     @Override
     protected AlertsNrqlCondition convertFromConfigItem(NrqlCondition condition) {
-        return AlertsNrqlCondition.builder()
-                .name(condition.getConditionName())
-                .enabled(condition.isEnabled())
-                .runbookUrl(condition.getRunBookUrl())
-                .terms(TermsUtils.createNrqlTerms(condition.getTerms()))
-                .valueFunction(condition.getValueFunction().getValueString())
-                .nrql(Nrql.builder()
-                        .sinceValue(String.valueOf(condition.getSinceValue().getSince()))
-                        .query(condition.getQuery())
-                        .build())
-                .build();
+        AlertsNrqlCondition.AlertsNrqlConditionBuilder nrqlConditionBuilder = AlertsNrqlCondition.builder()
+            .name(condition.getConditionName())
+            .enabled(condition.isEnabled())
+            .runbookUrl(condition.getRunBookUrl())
+            .terms(TermsUtils.createNrqlTerms(condition.getTerms()))
+            .valueFunction(condition.getValueFunction().getValueString())
+            .nrql(Nrql.builder()
+                .sinceValue(String.valueOf(condition.getSinceValue().getSince()))
+                .query(condition.getQuery())
+                .build());
+
+        condition.getSignal()
+            .ifPresent(nrqlSignalConfiguration -> nrqlConditionBuilder
+                .signal(SignalUtils.createSignal(nrqlSignalConfiguration))
+                .expiration(ExpirationUtils.createExpiration(nrqlSignalConfiguration.getSignalLostConfiguration()))
+            );
+
+        return nrqlConditionBuilder.build();
     }
 
     @Override

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/NrqlCondition.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/NrqlCondition.java
@@ -68,10 +68,6 @@ public class NrqlCondition {
      */
     private NrqlSignalConfiguration signal;
 
-    public Optional<NrqlSignalConfiguration> getSignal() {
-        return Optional.ofNullable(signal);
-    }
-
     @Getter
     @AllArgsConstructor
     public enum SinceValue {

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/NrqlCondition.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/NrqlCondition.java
@@ -1,13 +1,14 @@
 package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition;
 
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.NrqlSignalConfiguration;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.NrqlTermsConfiguration;
+import java.util.Collection;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Singular;
-
-import java.util.Collection;
 
 /**
  * NRQL condition.
@@ -20,6 +21,7 @@ import java.util.Collection;
  *     <li>{@link #valueFunction}</li>
  *     <li>{@link #query}</li>
  *     <li>{@link #sinceValue}</li>
+ *     <li>{@link #signal}</li>
  * </ul>
  */
 @Getter
@@ -60,6 +62,15 @@ public class NrqlCondition {
      */
     @NonNull
     private SinceValue sinceValue;
+
+    /**
+     * NRQL Signal configuration.
+     */
+    private NrqlSignalConfiguration signal;
+
+    public Optional<NrqlSignalConfiguration> getSignal() {
+        return Optional.ofNullable(signal);
+    }
 
     @Getter
     @AllArgsConstructor

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/ExpirationUtils.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/ExpirationUtils.java
@@ -1,0 +1,17 @@
+package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal;
+
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Expiration;
+
+public final class ExpirationUtils {
+
+    private ExpirationUtils() {
+    }
+
+    public static Expiration createExpiration(SignalLostConfiguration signalLostConfiguration) {
+        return Expiration.builder()
+            .expirationDuration(String.valueOf(signalLostConfiguration.getSignalIsLostAfter()))
+            .closeViolationsOnExpiration(signalLostConfiguration.isCloseCurrentViolationsOnSignalLost())
+            .openViolationOnExpiration(signalLostConfiguration.isOpenNewViolationOnSignalLost())
+            .build();
+    }
+}

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/NrqlSignalConfiguration.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/NrqlSignalConfiguration.java
@@ -1,0 +1,45 @@
+package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * NRQL Signal configuration.
+ * Configuration parameters:
+ * <ul>
+ *     <li>{@link #aggregationWindow}</li>
+ *     <li>{@link #evaluationWindows}</li>
+ *     <li>{@link #signalFillOption}</li>
+ *     <li>{@link #signalLostConfiguration}</li>
+ * </ul>
+ */
+@Builder
+@Getter
+public class NrqlSignalConfiguration {
+
+    /**
+     * Time (in seconds) for how long NewRelic collects data before running the NRQL query.
+     */
+    @NonNull
+    private Integer aggregationWindow;
+
+    /**
+     * Number of windows to evaluate data.
+     */
+    @NonNull
+    private Integer evaluationWindows;
+
+    /**
+     * Configuration of filling data gaps/signal lost.
+     */
+    @NonNull
+    private SignalFillOption signalFillOption;
+
+    /**
+     * Configuration of signal lost behaviour.
+     */
+    @NonNull
+    private SignalLostConfiguration signalLostConfiguration;
+
+}

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalFillOption.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalFillOption.java
@@ -1,0 +1,15 @@
+package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal;
+
+public enum SignalFillOption {
+    NONE("none"), LAST_KNOWN_VALUE("last_value");
+
+    private String value;
+
+    SignalFillOption(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalFillOption.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalFillOption.java
@@ -1,15 +1,13 @@
 package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum SignalFillOption {
     NONE("none"), LAST_KNOWN_VALUE("last_value");
 
-    private String value;
+    private final String value;
 
-    SignalFillOption(String value) {
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
 }

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalLostConfiguration.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalLostConfiguration.java
@@ -1,0 +1,36 @@
+package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * NRQL Signal lost configuration.
+ * Configuration parameters:
+ * <ul>
+ *     <li>{@link #signalIsLostAfter}</li>
+ *     <li>{@link #openNewViolationOnSignalLost}</li>
+ *     <li>{@link #closeCurrentViolationsOnSignalLost}</li>
+ * </ul>
+ */
+@Builder
+@Getter
+public class SignalLostConfiguration {
+
+    /**
+     * Time (in seconds) for the signal treated as lost.
+     */
+    @NonNull
+    private Integer signalIsLostAfter;
+
+    /**
+     * When true, this opens a loss of signal violation when no signal within {@link #signalIsLostAfter} time.
+     */
+    private boolean openNewViolationOnSignalLost;
+
+    /**
+     * When true, this closes all currently open violations when no signal is heard within {@link #signalIsLostAfter} time.
+     */
+    private boolean closeCurrentViolationsOnSignalLost;
+
+}

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalUtils.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalUtils.java
@@ -1,0 +1,17 @@
+package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal;
+
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Signal;
+
+public final class SignalUtils {
+
+    private SignalUtils() {
+    }
+
+    public static Signal createSignal(NrqlSignalConfiguration nrqlSignalConfiguration) {
+        return Signal.builder()
+            .aggregationWindow(String.valueOf(nrqlSignalConfiguration.getAggregationWindow()))
+            .evaluationOffset(String.valueOf(nrqlSignalConfiguration.getEvaluationWindows()))
+            .fillOption(nrqlSignalConfiguration.getSignalFillOption().getValue())
+            .build();
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/Expiration.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/Expiration.java
@@ -1,0 +1,20 @@
+package com.ocadotechnology.newrelic.apiclient.model.conditions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@AllArgsConstructor
+public class Expiration {
+
+    @JsonProperty("expiration_duration")
+    String expirationDuration;
+    @JsonProperty("open_violation_on_expiration")
+    boolean openViolationOnExpiration;
+    @JsonProperty("close_violations_on_expiration")
+    boolean closeViolationsOnExpiration;
+
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/Signal.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/Signal.java
@@ -1,0 +1,18 @@
+package com.ocadotechnology.newrelic.apiclient.model.conditions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@AllArgsConstructor
+public class Signal {
+    @JsonProperty("aggregation_window")
+    String aggregationWindow;
+    @JsonProperty("evaluation_offset")
+    String evaluationOffset;
+    @JsonProperty("fill_option")
+    String fillOption;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/AlertsNrqlCondition.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/AlertsNrqlCondition.java
@@ -2,14 +2,15 @@ package com.ocadotechnology.newrelic.apiclient.model.conditions.nrql;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ocadotechnology.newrelic.apiclient.model.PolicyItem;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Expiration;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Signal;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.Terms;
+import java.util.Collection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Singular;
 import lombok.Value;
 import lombok.experimental.NonFinal;
-
-import java.util.Collection;
 
 /**
  * See <a href="https://rpm.newrelic.com/api/explore/alerts_nrql_conditions/list">Doc</a>
@@ -34,4 +35,8 @@ public class AlertsNrqlCondition implements PolicyItem {
     String valueFunction;
     @JsonProperty
     Nrql nrql;
+    @JsonProperty
+    Signal signal;
+    @JsonProperty
+    Expiration expiration;
 }


### PR DESCRIPTION
This pull request adds support for new feature of Signal configuration. It is useful when e.g application is down/not running and NR will raise violation that there is no data/signal from NR agent.

More info here: https://docs.newrelic.com/whats-new/alerting-loss-signal-detection-configurable-gap-filling-strategies