### PR TITLE
Add support for loss of signal detection in NRQL alerts

### DIFF
--- a/newrelic-alerts-configurator-dsl/src/main/kotlin/com/ocadotechnology/newrelic/alertsconfigurator/dsl/configuration/condition/NrqlConditionDsl.kt
+++ b/newrelic-alerts-configurator-dsl/src/main/kotlin/com/ocadotechnology/newrelic/alertsconfigurator/dsl/configuration/condition/NrqlConditionDsl.kt
@@ -1,6 +1,8 @@
 package com.ocadotechnology.newrelic.alertsconfigurator.dsl.configuration.condition
 
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.NrqlCondition
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal.ExpirationConfiguration
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal.SignalConfiguration
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.NrqlTermsConfiguration
 import com.ocadotechnology.newrelic.alertsconfigurator.dsl.NewRelicConfigurationMarker
 import com.ocadotechnology.newrelic.alertsconfigurator.dsl.configuration.condition.terms.NrqlTermConfigurations
@@ -14,6 +16,8 @@ class NrqlConditionDsl {
     var query: String? = null
     var sinceValue: NrqlCondition.SinceValue? = null
     internal val terms: MutableList<NrqlTermsConfiguration> = mutableListOf()
+    var expiration: ExpirationConfiguration? = null
+    var signal: SignalConfiguration? = null
 
     fun terms(block: NrqlTermConfigurations.() -> Unit) = terms.addAll(NrqlTermConfigurations().apply(block).terms)
 }
@@ -30,5 +34,7 @@ fun nrqlCondition(block: NrqlConditionDsl.() -> Unit): NrqlCondition {
             .valueFunction(requireNotNull(dsl.valueFunction) { "Nrql condition value cannot be null" })
             .query(requireNotNull(dsl.query) { "Nrql condition query cannot be null" })
             .sinceValue(requireNotNull(dsl.sinceValue) { "Nrql condition since cannot be null" })
+            .expiration(dsl.expiration)
+            .signal(dsl.signal)
             .build()
 }

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfigurator.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfigurator.java
@@ -1,11 +1,10 @@
 package com.ocadotechnology.newrelic.alertsconfigurator;
 
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.PolicyConfiguration;
-
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.NrqlCondition;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal.LossOfSignalUtils;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.TermsUtils;
 import com.ocadotechnology.newrelic.apiclient.NewRelicApi;
-
 import com.ocadotechnology.newrelic.apiclient.PolicyItemApi;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.Nrql;
@@ -45,6 +44,8 @@ class NrqlConditionConfigurator extends AbstractPolicyItemConfigurator<AlertsNrq
                         .sinceValue(String.valueOf(condition.getSinceValue().getSince()))
                         .query(condition.getQuery())
                         .build())
+                .expiration(LossOfSignalUtils.createExpiration(condition.getExpiration()))
+                .signal(LossOfSignalUtils.createSignal(condition.getSignal()))
                 .build();
     }
 

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/NrqlCondition.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/NrqlCondition.java
@@ -1,5 +1,7 @@
 package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition;
 
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal.ExpirationConfiguration;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal.SignalConfiguration;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.NrqlTermsConfiguration;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +22,8 @@ import java.util.Collection;
  *     <li>{@link #valueFunction}</li>
  *     <li>{@link #query}</li>
  *     <li>{@link #sinceValue}</li>
+ *     <li>{@link #expiration}</li>
+ *     <li>{@link #signal}</li>
  * </ul>
  */
 @Getter
@@ -60,6 +64,17 @@ public class NrqlCondition {
      */
     @NonNull
     private SinceValue sinceValue;
+
+    /**
+     * Expiration configuration to customise the loss of signal detection
+     */
+    private ExpirationConfiguration expiration;
+
+    /**
+     *  Signal configuration to customise the gap filling
+     */
+    private SignalConfiguration signal;
+
 
     @Getter
     @AllArgsConstructor

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/lossofsignal/ExpirationConfiguration.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/lossofsignal/ExpirationConfiguration.java
@@ -1,0 +1,73 @@
+package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Expiration configuration to customise the loss of signal detection
+ * Configuration parameters:
+ * <ul>
+ *     <li>{@link #expirationDuration}</li>
+ *     <li>{@link #openViolationOnExpiration}</li>
+ *     <li>{@link #closeViolationsOnExpiration}</li>
+ * </ul>
+ */
+@Builder
+@Value
+public class ExpirationConfiguration {
+    /**
+     * The wait duration (in seconds) since the last data point is received before considering the signal is lost
+     */
+    long expirationDuration;
+
+    /**
+     * If {@code true} opens a loss of signal violation when there was no signal within the {@link #expirationDuration} time
+     * Requires a value to be set in {@link #expirationDuration}
+     */
+    boolean openViolationOnExpiration;
+
+    /**
+     * If {@code true} closes all the open violations when there was no signal within the {@link #expirationDuration}
+     * Requires a value to be set in {@link #expirationDuration}
+     */
+    boolean closeViolationsOnExpiration;
+
+    public static class ExpirationConfigurationBuilder {
+        public ExpirationConfigurationBuilder expirationDuration(int duration, TimeUnit unit) {
+            this.expirationDuration = unit.toSeconds(duration);
+            return this;
+        }
+
+        public ExpirationConfigurationBuilder expirationDuration(ExpirationDuration duration){
+            this.expirationDuration = duration.getTimeInSeconds();
+            return this;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public enum ExpirationDuration {
+        SECOND(1),
+        SECONDS_2(2),
+        SECONDS_3(3),
+        SECONDS_4(4),
+        SECONDS_5(5),
+        SECONDS_10(10),
+        SECONDS_15(15),
+        SECONDS_30(30),
+        MINUTE(60),
+        MINUTES_2(120),
+        MINUTES_3(180),
+        MINUTES_4(240),
+        MINUTES_5(300),
+        MINUTES_10(600),
+        MINUTES_15(900),
+        MINUTES_30(1800);
+
+        private final int timeInSeconds;
+    }
+}

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/lossofsignal/LossOfSignalUtils.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/lossofsignal/LossOfSignalUtils.java
@@ -1,0 +1,26 @@
+package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal;
+
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.Expiration;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.Signal;
+
+public class LossOfSignalUtils {
+    private LossOfSignalUtils() {
+    }
+
+    public static Expiration createExpiration(ExpirationConfiguration expiration) {
+        return Expiration.builder()
+                .expirationDuration(String.valueOf(expiration.getExpirationDuration()))
+                .closeViolationsOnExpiration(expiration.isCloseViolationsOnExpiration())
+                .openViolationOnExpiration(expiration.isOpenViolationOnExpiration())
+                .build();
+    }
+
+    public static Signal createSignal(SignalConfiguration signal) {
+        return Signal.builder()
+                .evaluationOffset(String.valueOf(signal.getEvaluationOffset()))
+                .aggregationWindow(String.valueOf(signal.getAggregationWindow()))
+                .fillValue(signal.getFillValue())
+                .fillOption(signal.getFillOption().getValue())
+                .build();
+    }
+}

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/lossofsignal/SignalConfiguration.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/lossofsignal/SignalConfiguration.java
@@ -1,0 +1,120 @@
+package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Signal configuration to customise the gap filling
+ * Configuration parameters:
+ * <ul>
+ *     <li>{@link #fillOption}</li>
+ *     <li>{@link #fillValue}</li>
+ *     <li>{@link #aggregationWindow}</li>
+ *     <li>{@link #evaluationOffset}</li>
+ * </ul>
+ */
+@Builder
+@Getter
+public class SignalConfiguration {
+    /**
+     * Fill option to avoid false alerts by filling the gaps with synthetic data from {@link #fillValue}
+     */
+    @NonNull
+    @Builder.Default
+    private FillOption fillOption = FillOption.NONE;
+
+    /**
+     * The custom static value used when {@link FillOption#STATIC} is set
+     */
+    @NonNull
+    private String fillValue;
+
+    /**
+     * The window of time (in minutes) defining how streamed data points will be gathered together before executing NRQL query
+     */
+    @NonNull
+    private long aggregationWindow;
+
+    /**
+     * The evaluation offset (in minutes) defining how long we should wait for late data before evaluating each aggregation windows
+     */
+    @NonNull
+    private long evaluationOffset;
+
+    public static class SignalConfigurationBuilder{
+        public SignalConfigurationBuilder aggregationWindow(AggregationWindow window){
+            this.aggregationWindow = window.getTimeInMinutes();
+            return this;
+        }
+
+        public SignalConfigurationBuilder aggregationWindow(long duration, TimeUnit unit){
+            this.aggregationWindow = unit.toMinutes(duration);
+            return this;
+        }
+
+        public SignalConfigurationBuilder evaluationOffset(EvaluationOffset offset){
+            this.evaluationOffset = offset.timeInMinutes;
+            return this;
+        }
+
+        public SignalConfigurationBuilder evaluationOffset(long duration, TimeUnit unit){
+            this.evaluationOffset = unit.toMinutes(duration);
+            return this;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public enum FillOption {
+        NONE("none"),
+        LAST_VALUE("last_value"),
+        STATIC("static");
+
+        private final String value;
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    public enum AggregationWindow {
+        WINDOW_1(1),
+        WINDOW_2(2),
+        WINDOW_3(3),
+        WINDOW_4(4),
+        WINDOW_5(5),
+        WINDOW_6(6),
+        WINDOW_7(7),
+        WINDOW_8(8),
+        WINDOW_9(9),
+        WINDOW_10(10),
+        WINDOW_11(11),
+        WINDOW_12(12),
+        WINDOW_13(13),
+        WINDOW_14(14),
+        WINDOW_15(15);
+
+        private final int timeInMinutes;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public enum EvaluationOffset {
+        OFFSET_1(1),
+        OFFSET_2(2),
+        OFFSET_3(3),
+        OFFSET_4(4),
+        OFFSET_5(5),
+        OFFSET_10(10),
+        OFFSET_15(15),
+        OFFSET_30(30),
+        OFFSET_60(60),
+        OFFSET_120(120);
+
+        private final int timeInMinutes;
+    }
+
+}

--- a/newrelic-alerts-configurator/src/test/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfiguratorTest.java
+++ b/newrelic-alerts-configurator/src/test/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfiguratorTest.java
@@ -2,12 +2,23 @@ package com.ocadotechnology.newrelic.alertsconfigurator;
 
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.PolicyConfiguration;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.NrqlCondition;
-import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.*;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal.ExpirationConfiguration;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal.SignalConfiguration;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.lossofsignal.SignalConfiguration.FillOption;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.NrqlDurationTerm;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.NrqlTermsConfiguration;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.OperatorTerm;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.PriorityTerm;
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.terms.TimeFunctionTerm;
 import com.ocadotechnology.newrelic.apiclient.PolicyItemApi;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.Terms;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.Expiration;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.Nrql;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.Signal;
 import org.junit.Before;
+
+import java.util.concurrent.TimeUnit;
 
 public class NrqlConditionConfiguratorTest extends AbstractPolicyItemConfiguratorTest<NrqlConditionConfigurator, AlertsNrqlCondition> {
 
@@ -15,6 +26,16 @@ public class NrqlConditionConfiguratorTest extends AbstractPolicyItemConfigurato
     private static final NrqlCondition.ValueFunction VALUE_FUNCTION = NrqlCondition.ValueFunction.SINGLE_VALUE;
     private static final NrqlCondition.SinceValue SINCE_VALUE = NrqlCondition.SinceValue.SINCE_1;
     private static final String QUERY = "query";
+
+    private static final FillOption FILL_OPTION = FillOption.STATIC;
+    private static final String FILL_VALUE = "123";
+    private static final int AGGREGATION_WINDOW_MINUTES = 3;
+    private static final int EVALUATION_OFFSET_MINUTES = 5;
+
+    private static final int EXPIRATION_DURATION_SECONDS = 10;
+    private static final boolean OPEN_VIOLATION_ON_EXPIRATION = true;
+    private static final boolean CLOSE_VIOLATIONS_ON_EXPIRATION = true;
+
     private static final NrqlCondition NRQL_CONDITION = createNrqlCondition(CONDITION_NAME);
 
     private static final AlertsNrqlCondition ALERTS_CONDITION_SAME = createConditionBuilder().id(1).build();
@@ -78,6 +99,17 @@ public class NrqlConditionConfiguratorTest extends AbstractPolicyItemConfigurato
                 .valueFunction(VALUE_FUNCTION)
                 .query(QUERY)
                 .sinceValue(SINCE_VALUE)
+                .expiration(ExpirationConfiguration.builder()
+                        .closeViolationsOnExpiration(CLOSE_VIOLATIONS_ON_EXPIRATION)
+                        .openViolationOnExpiration(OPEN_VIOLATION_ON_EXPIRATION)
+                        .expirationDuration(EXPIRATION_DURATION_SECONDS, TimeUnit.SECONDS)
+                        .build())
+                .signal(SignalConfiguration.builder()
+                        .aggregationWindow(AGGREGATION_WINDOW_MINUTES, TimeUnit.MINUTES)
+                        .evaluationOffset(EVALUATION_OFFSET_MINUTES, TimeUnit.MINUTES)
+                        .fillOption(FILL_OPTION)
+                        .fillValue(FILL_VALUE)
+                        .build())
                 .build();
     }
 
@@ -104,6 +136,17 @@ public class NrqlConditionConfiguratorTest extends AbstractPolicyItemConfigurato
                 .nrql(Nrql.builder()
                         .query(QUERY)
                         .sinceValue(String.valueOf(SINCE_VALUE.getSince()))
+                        .build())
+                .signal(Signal.builder()
+                        .fillOption(FILL_OPTION.getValue())
+                        .fillValue(FILL_VALUE)
+                        .aggregationWindow(String.valueOf(AGGREGATION_WINDOW_MINUTES))
+                        .evaluationOffset(String.valueOf(EVALUATION_OFFSET_MINUTES))
+                        .build())
+                .expiration(Expiration.builder()
+                        .expirationDuration(String.valueOf(EXPIRATION_DURATION_SECONDS))
+                        .openViolationOnExpiration(OPEN_VIOLATION_ON_EXPIRATION)
+                        .closeViolationsOnExpiration(CLOSE_VIOLATIONS_ON_EXPIRATION)
                         .build());
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/AlertsNrqlCondition.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/AlertsNrqlCondition.java
@@ -34,4 +34,8 @@ public class AlertsNrqlCondition implements PolicyItem {
     String valueFunction;
     @JsonProperty
     Nrql nrql;
+    @JsonProperty
+    Signal signal;
+    @JsonProperty
+    Expiration expiration;
 }

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/Expiration.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/Expiration.java
@@ -1,0 +1,18 @@
+package com.ocadotechnology.newrelic.apiclient.model.conditions.nrql;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@AllArgsConstructor
+public class Expiration {
+    @JsonProperty("expiration_duration")
+    String expirationDuration;
+    @JsonProperty("open_violation_on_expiration")
+    boolean openViolationOnExpiration;
+    @JsonProperty("close_violations_on_expiration")
+    boolean closeViolationsOnExpiration;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/Signal.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/Signal.java
@@ -1,0 +1,20 @@
+package com.ocadotechnology.newrelic.apiclient.model.conditions.nrql;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@AllArgsConstructor
+public class Signal {
+    @JsonProperty("aggregation_window")
+    String aggregationWindow;
+    @JsonProperty("evaluation_offset")
+    String evaluationOffset;
+    @JsonProperty("fill_option")
+    String fillOption;
+    @JsonProperty("fill_value")
+    String fillValue;
+}


### PR DESCRIPTION
Adds `expiration` and `signal` that allows user to configure loss of signal detection and gap filling.  
More details: [here](https://docs.newrelic.com/whats-new/alerting-loss-signal-detection-configurable-gap-filling-strategies)