### PR TITLE
Fix setting explicit null value for field 'fill_value' in Signal configuration

### DIFF
--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalUtils.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalUtils.java
@@ -12,6 +12,7 @@ public final class SignalUtils {
             .aggregationWindow(String.valueOf(nrqlSignalConfiguration.getAggregationWindow()))
             .evaluationOffset(String.valueOf(nrqlSignalConfiguration.getEvaluationWindows()))
             .fillOption(nrqlSignalConfiguration.getSignalFillOption().getValue())
+            .fillValue(null)
             .build();
     }
 }

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/Signal.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/Signal.java
@@ -1,5 +1,6 @@
 package com.ocadotechnology.newrelic.apiclient.model.conditions;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,4 +16,7 @@ public class Signal {
     String evaluationOffset;
     @JsonProperty("fill_option")
     String fillOption;
+    @JsonInclude
+    @JsonProperty("fill_value")
+    String fillValue;
 }


### PR DESCRIPTION
This pull request fix scenario when 'static' value has been used in 'fill_option' field via NewRelic UI. NewRelic API needs to get explicit null value when setting when 'fill_option' field takes 'none' or 'last_value' (only values supported by newrelic-alerts-configurator library).