### PR TITLE
Fix for 404 while fetching policy's nrql conditions on random accounts

### DIFF
--- a/newrelic-alerts-configurator/src/test/java/com/ocadotechnology/newrelic/alertsconfigurator/ConfiguratorTest.java
+++ b/newrelic-alerts-configurator/src/test/java/com/ocadotechnology/newrelic/alertsconfigurator/ConfiguratorTest.java
@@ -10,7 +10,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.ImmutableList;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.ApplicationConfiguration;

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsNrqlConditionsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsNrqlConditionsApi.java
@@ -13,7 +13,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
 class DefaultAlertsNrqlConditionsApi extends ApiBase implements PolicyItemApi<AlertsNrqlCondition> {
 
-    private static final String CONDITIONS_URL = "/v2/alerts_nrql_conditions";
+    private static final String CONDITIONS_URL = "/v2/alerts_nrql_conditions.json";
     private static final String CONDITION_URL = "/v2/alerts_nrql_conditions/{condition_id}.json";
     private static final String CONDITION_POLICY_URL = "/v2/alerts_nrql_conditions/policies/{policy_id}.json";
 

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDashboardsApiTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDashboardsApiTest.java
@@ -8,7 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultSyntheticsMonitorsApiTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultSyntheticsMonitorsApiTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;


### PR DESCRIPTION
Fix for 404 while fetching policy's nrql conditions on random accounts 
+ switched deprecated org.mockito.runners.MockitoJUnitRunner into org.mockito.junit.MockitoJUnitRunner in tests (I've spotted this so decided to update that)