### PR TITLE
Add support for signal configuration without expiration

### DIFF
--- a/newrelic-alerts-configurator-dsl/src/main/kotlin/com/ocadotechnology/newrelic/alertsconfigurator/dsl/configuration/condition/NrqlConditionConfigurationDsl.kt
+++ b/newrelic-alerts-configurator-dsl/src/main/kotlin/com/ocadotechnology/newrelic/alertsconfigurator/dsl/configuration/condition/NrqlConditionConfigurationDsl.kt
@@ -1,6 +1,5 @@
 package com.ocadotechnology.newrelic.alertsconfigurator.dsl.configuration.condition
 
-import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.UserDefinedConfiguration
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.NrqlSignalConfiguration
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.SignalFillOption
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.SignalLostConfiguration
@@ -27,7 +26,6 @@ fun nrqlSignalConfiguration(block: NrqlSignalConfigurationDsl.() -> Unit): NrqlS
             .aggregationWindow(requireNotNull(dsl.aggregationWindow) { "Aggregation window cannot be null" })
             .evaluationWindows(requireNotNull(dsl.evaluationWindows) { "Evaluation window cannot be null" })
             .signalFillOption(requireNotNull(dsl.signalFillOption) { "Signal fill option cannot be null" })
-            .signalLostConfiguration(requireNotNull(dsl.signalLostConfiguration) { "Signal lost configuration cannot be null" })
     if (dsl.signalFillOption == SignalFillOption.STATIC) {
         signalConfigurationBuilder.signalFillValue(requireNotNull(dsl.signalFillValue) {"Signal fill value is required when signal fill is STATIC"})
     }

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/ExpirationUtils.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/ExpirationUtils.java
@@ -8,6 +8,9 @@ public final class ExpirationUtils {
     }
 
     public static Expiration createExpiration(SignalLostConfiguration signalLostConfiguration) {
+        if (signalLostConfiguration == null) {
+            return null;
+        }
         return Expiration.builder()
             .expirationDuration(String.valueOf(signalLostConfiguration.getSignalIsLostAfter()))
             .closeViolationsOnExpiration(signalLostConfiguration.isCloseCurrentViolationsOnSignalLost())

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/NrqlSignalConfiguration.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/NrqlSignalConfiguration.java
@@ -45,7 +45,6 @@ public class NrqlSignalConfiguration {
     /**
      * Configuration of signal lost behaviour.
      */
-    @NonNull
     private SignalLostConfiguration signalLostConfiguration;
 
 }


### PR DESCRIPTION
Why this change? We tried to set aggregation_window to NRQL alert where query is nested (e.g. `SELECT max(param) FROM (SELECT param FROM Transaction FACET name)`) but it couldn't be set with signal loss config:
``` com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClientInterceptor - {"error":{"title":"NRQL query has invalid nested query: Signal loss is not enabled for nested queries."}} ```