### PR TITLE
Adapt to Signal having aggregationMethod; remove evaluationOffset 

### DIFF
--- a/newrelic-alerts-configurator-dsl/src/main/kotlin/com/ocadotechnology/newrelic/alertsconfigurator/dsl/configuration/condition/NrqlConditionConfigurationDsl.kt
+++ b/newrelic-alerts-configurator-dsl/src/main/kotlin/com/ocadotechnology/newrelic/alertsconfigurator/dsl/configuration/condition/NrqlConditionConfigurationDsl.kt
@@ -1,6 +1,7 @@
 package com.ocadotechnology.newrelic.alertsconfigurator.dsl.configuration.condition
 
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.NrqlSignalConfiguration
+import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.SignalAggregationMethod
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.SignalFillOption
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.SignalLostConfiguration
 import com.ocadotechnology.newrelic.alertsconfigurator.dsl.NewRelicConfigurationMarker
@@ -8,7 +9,8 @@ import com.ocadotechnology.newrelic.alertsconfigurator.dsl.NewRelicConfiguration
 @NewRelicConfigurationMarker
 class NrqlSignalConfigurationDsl {
     var aggregationWindow: Int? = null
-    var evaluationWindows: Int? = null
+    var aggregationMethod: SignalAggregationMethod? = null
+    var aggregationDelay: Int? = null
     var signalFillOption: SignalFillOption? = null
     var signalFillValue: String? = null
     var signalLostConfiguration: SignalLostConfiguration? = null
@@ -23,8 +25,9 @@ fun nrqlSignalConfiguration(block: NrqlSignalConfigurationDsl.() -> Unit): NrqlS
     dsl.block()
 
     val signalConfigurationBuilder = NrqlSignalConfiguration.builder()
+            .aggregationMethod(requireNotNull(dsl.aggregationMethod) { "Aggregation method cannot be null" })
             .aggregationWindow(requireNotNull(dsl.aggregationWindow) { "Aggregation window cannot be null" })
-            .evaluationWindows(requireNotNull(dsl.evaluationWindows) { "Evaluation window cannot be null" })
+            .aggregationDelay(requireNotNull(dsl.aggregationDelay) { "Aggregation delay cannot be null" })
             .signalFillOption(requireNotNull(dsl.signalFillOption) { "Signal fill option cannot be null" })
             .signalLostConfiguration(dsl.signalLostConfiguration)
     if (dsl.signalFillOption == SignalFillOption.STATIC) {

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfigurator.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/NrqlConditionConfigurator.java
@@ -16,6 +16,8 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+import static com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal.SignalUtils.intToStringOrNull;
+
 @Slf4j
 class NrqlConditionConfigurator extends AbstractPolicyItemConfigurator<AlertsNrqlCondition, NrqlCondition> {
 
@@ -42,7 +44,7 @@ class NrqlConditionConfigurator extends AbstractPolicyItemConfigurator<AlertsNrq
             .terms(TermsUtils.createNrqlTerms(condition.getTerms()))
             .valueFunction(condition.getValueFunction().getValueString())
             .nrql(Nrql.builder()
-                .sinceValue(String.valueOf(condition.getSinceValue().getSince()))
+                .sinceValue(getSinceValueOrNull(condition))
                 .query(condition.getQuery())
                 .build());
 
@@ -54,6 +56,10 @@ class NrqlConditionConfigurator extends AbstractPolicyItemConfigurator<AlertsNrq
         }
 
         return nrqlConditionBuilder.build();
+    }
+
+    private String getSinceValueOrNull(NrqlCondition condition) {
+        return condition.getSinceValue() != null ? intToStringOrNull(condition.getSinceValue().getSince()) : null;
     }
 
     @Override

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/NrqlCondition.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/NrqlCondition.java
@@ -60,7 +60,6 @@ public class NrqlCondition {
     /**
      * This is the timeframe in which to evaluate the {@link #query}
      */
-    @NonNull
     private SinceValue sinceValue;
 
     /**

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/NrqlSignalConfiguration.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/NrqlSignalConfiguration.java
@@ -8,8 +8,8 @@ import lombok.NonNull;
  * NRQL Signal configuration.
  * Configuration parameters:
  * <ul>
+ *     <li>{@link #aggregationMethod}</li>
  *     <li>{@link #aggregationWindow}</li>
- *     <li>{@link #evaluationWindows}</li>
  *     <li>{@link #signalFillOption}</li>
  *     <li>{@link #signalFillValue}</li>
  *     <li>{@link #signalLostConfiguration}</li>
@@ -20,16 +20,24 @@ import lombok.NonNull;
 public class NrqlSignalConfiguration {
 
     /**
+     * Configuration of signal aggregation method.
+     * For reference see: <a href="https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts/#aggregation-methods">NR Docs</a>
+     */
+    @NonNull
+    private SignalAggregationMethod aggregationMethod;
+
+    /**
+     * Delay is how long we wait for events that belong in each aggregation window.
+     * Depending on your data a longer delay may increase accuracy but delay notifications.
+     */
+    @NonNull
+    private Integer aggregationDelay;
+
+    /**
      * Time (in seconds) for how long NewRelic collects data before running the NRQL query.
      */
     @NonNull
     private Integer aggregationWindow;
-
-    /**
-     * Number of windows to evaluate data.
-     */
-    @NonNull
-    private Integer evaluationWindows;
 
     /**
      * Configuration of filling data gaps/signal lost.

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalAggregationMethod.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalAggregationMethod.java
@@ -1,0 +1,12 @@
+package com.ocadotechnology.newrelic.alertsconfigurator.configuration.condition.signal;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SignalAggregationMethod {
+    EVENT_FLOW("EVENT_FLOW"), EVENT_TIMER("EVENT_TIMER"), CADENCE("CADENCE");
+
+    private final String value;
+}

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalUtils.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/configuration/condition/signal/SignalUtils.java
@@ -9,10 +9,15 @@ public final class SignalUtils {
 
     public static Signal createSignal(NrqlSignalConfiguration nrqlSignalConfiguration) {
         return Signal.builder()
-            .aggregationWindow(String.valueOf(nrqlSignalConfiguration.getAggregationWindow()))
-            .evaluationOffset(String.valueOf(nrqlSignalConfiguration.getEvaluationWindows()))
+            .aggregationMethod(nrqlSignalConfiguration.getAggregationMethod().getValue())
+            .aggregationDelay(intToStringOrNull(nrqlSignalConfiguration.getAggregationDelay()))
+            .aggregationWindow(intToStringOrNull(nrqlSignalConfiguration.getAggregationWindow()))
             .fillOption(nrqlSignalConfiguration.getSignalFillOption().getValue())
             .fillValue(nrqlSignalConfiguration.getSignalFillValue())
             .build();
+    }
+
+    public static String intToStringOrNull(Integer integer) {
+        return integer != null ? String.valueOf(integer) : null;
     }
 }

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/Signal.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/Signal.java
@@ -10,10 +10,12 @@ import lombok.Value;
 @Builder
 @AllArgsConstructor
 public class Signal {
+    @JsonProperty("aggregation_method")
+    String aggregationMethod;
+    @JsonProperty("aggregation_delay")
+    String aggregationDelay;
     @JsonProperty("aggregation_window")
     String aggregationWindow;
-    @JsonProperty("evaluation_offset")
-    String evaluationOffset;
     @JsonProperty("fill_option")
     String fillOption;
     @JsonInclude

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/Nrql.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/conditions/nrql/Nrql.java
@@ -1,9 +1,12 @@
 package com.ocadotechnology.newrelic.apiclient.model.conditions.nrql;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Value
 @Builder
@@ -11,6 +14,7 @@ import lombok.Value;
 public class Nrql {
     @JsonProperty
     String query;
+    @JsonInclude(NON_NULL)
     @JsonProperty("since_value")
     String sinceValue;
 }


### PR DESCRIPTION
* signal now supports aggregationMethod
* when aggregationMethod is used, evaluationOffset might not be passed (aggregationDelay is expected)
* singe aggregationMethod is now required by NewRelic UI to save alert, it is therefore added as nonNull, and evaluationOffset is removed.