### PR TITLE
Added NewRelicHybridApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,23 @@ This code creates alert policy that will raise critical alert whenever some-host
  minutes. Information about alert will be emailed to my-team@my-company.com
  
 More examples can be found in [newrelic-alerts-configurator-examples](newrelic-alerts-configurator-examples) module.
- 
-## How to obtain New Relic REST API key
 
-In above example we used **MY_REST_API_KEY**. Details on how to obtain it can be found in 
-[NewRelic's REST API docs](https://docs.newrelic.com/docs/apis/rest-api-v2/getting-started/api-keys)
+### Experimental configurator
+NewRelic actively deprecates parts of it's REST API encouraging a shift towards GraphQL API. 
+There is therefore an alternative configurator that uses [NewRelic GraphQL API](https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/) where possible.
+At this point it's experimental.
+```java
+NewRelicApi api = new NewRelicHybridApi("MY_REST_API_KEY", MY_ACCOUNT_ID);
+Configurator configurator = new Configurator(api);
+```
+ 
+## How to obtain New Relic REST API key and account ID
+
+In above examples we used **MY_REST_API_KEY** and **MY_ACCOUNT_ID**.  
+Details on how to obtain API key can be found in
+[NewRelic's REST API docs](https://docs.newrelic.com/docs/apis/rest-api-v2/getting-started/api-keys)  
+Details on how to obtain account ID can be found in
+[NewRelic's account docs](https://docs.newrelic.com/docs/accounts/accounts-billing/account-structure/account-id/)
 
 **Note that for some configurations you will need Admin User's New Relic API key!**
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ configure(subprojects - project(':newrelic-alerts-configurator-examples')) {
         archives javadocJar, sourcesJar
     }
 
-    if(project.hasProperty('release')) {
+    if (project.hasProperty('release')) {
         signing {
             required { !version.endsWith("-SNAPSHOT") && gradle.taskGraph.hasTask("uploadArchives") }
             sign configurations.archives
@@ -119,6 +119,11 @@ project(':newrelic-api-client') {
         api 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
         api 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.1'
         api 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.1'
+        implementation 'org.apache.commons:commons-text:1.10.0'
+        implementation('com.github.k0kubun:graphql-query-builder:0.4.2') {
+            exclude group: 'com.google.guava', module: 'guava'
+        }
+
     }
 }
 
@@ -130,7 +135,7 @@ project(':newrelic-alerts-configurator') {
 
 project(':newrelic-alerts-configurator-examples') {
     apply plugin: 'kotlin'
-    
+
     dependencies {
         api project(':newrelic-alerts-configurator')
         api project(':newrelic-alerts-configurator-dsl')

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/AbstractPolicyItemConfigurator.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/AbstractPolicyItemConfigurator.java
@@ -83,7 +83,7 @@ abstract class AbstractPolicyItemConfigurator<T extends PolicyItem, U> implement
                 .filter(item -> !updatedItemsIds.contains(item.getId()))
                 .forEach(
                         item -> {
-                            getItemsApi().delete(item.getId());
+                            getItemsApi().delete(policy.getId(), item.getId());
                             LOG.info("Item {} (id: {}) removed from policy {} (id: {})", item.getName(), item.getId(), policy.getName(), policy.getId());
                         }
                 );

--- a/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/Configurator.java
+++ b/newrelic-alerts-configurator/src/main/java/com/ocadotechnology/newrelic/alertsconfigurator/Configurator.java
@@ -1,14 +1,14 @@
 package com.ocadotechnology.newrelic.alertsconfigurator;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.ApplicationConfiguration;
 import com.ocadotechnology.newrelic.alertsconfigurator.configuration.PolicyConfiguration;
 import com.ocadotechnology.newrelic.alertsconfigurator.internal.entities.EntityResolver;
 import com.ocadotechnology.newrelic.apiclient.NewRelicApi;
-
+import com.ocadotechnology.newrelic.apiclient.NewRelicRestApi;
 import lombok.NonNull;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Main class used in configuration process. It is responsible for synchronizing programmatically created definitions of
@@ -43,7 +43,7 @@ public class Configurator {
      * @param apiKey API Key for given NewRelic account
      */
     public Configurator(@NonNull String apiKey) {
-        this(new NewRelicApi(apiKey));
+        this(new NewRelicRestApi(apiKey));
     }
 
     /**

--- a/newrelic-alerts-configurator/src/test/java/com/ocadotechnology/newrelic/alertsconfigurator/AbstractPolicyItemConfiguratorTest.java
+++ b/newrelic-alerts-configurator/src/test/java/com/ocadotechnology/newrelic/alertsconfigurator/AbstractPolicyItemConfiguratorTest.java
@@ -21,9 +21,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public abstract class AbstractPolicyItemConfiguratorTest<T extends PolicyItemConfigurator, U extends PolicyItem> extends AbstractConfiguratorTest {
     @Rule
@@ -190,7 +188,7 @@ public abstract class AbstractPolicyItemConfiguratorTest<T extends PolicyItemCon
         InOrder order = inOrder(itemApiMock);
         order.verify(itemApiMock).list(POLICY.getId());
         order.verify(itemApiMock).create(POLICY.getId(), itemFromConfig);
-        order.verify(itemApiMock).delete(itemDifferent.getId());
+        order.verify(itemApiMock).delete(POLICY.getId(), itemDifferent.getId());
         order.verifyNoMoreInteractions();
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/NewRelicApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/NewRelicApi.java
@@ -1,98 +1,38 @@
 package com.ocadotechnology.newrelic.apiclient;
 
-import com.ocadotechnology.newrelic.apiclient.internal.NewRelicInternalApi;
-import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClientFactory;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.AlertsCondition;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.external.AlertsExternalServiceCondition;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.synthetics.AlertsSyntheticsCondition;
-import lombok.Getter;
 
 /**
- * API facade - object exposing NewRelic API endpoints as Java methods. Requires API key.
+ * API facade - interface exposing NewRelic API as Java methods.
  */
-@Getter
-public class NewRelicApi {
+public interface NewRelicApi {
 
-    private static final String REST_API_URL = "https://api.newrelic.com";
-    private static final String SYNTHETICS_URL = "https://synthetics.newrelic.com/synthetics/api";
+    ApplicationsApi getApplicationsApi();
 
-    private final ApplicationsApi applicationsApi;
+    AlertsChannelsApi getAlertsChannelsApi();
 
-    private final AlertsChannelsApi alertsChannelsApi;
+    AlertsPoliciesApi getAlertsPoliciesApi();
 
-    private final AlertsPoliciesApi alertsPoliciesApi;
+    PolicyItemApi<AlertsCondition> getAlertsConditionsApi();
 
-    private final PolicyItemApi<AlertsCondition> alertsConditionsApi;
+    PolicyItemApi<AlertsNrqlCondition> getAlertsNrqlConditionsApi();
 
-    private final PolicyItemApi<AlertsNrqlCondition> alertsNrqlConditionsApi;
+    PolicyItemApi<AlertsExternalServiceCondition> getAlertsExternalServiceConditionsApi();
 
-    private final PolicyItemApi<AlertsExternalServiceCondition> alertsExternalServiceConditionsApi;
+    PolicyItemApi<AlertsSyntheticsCondition> getAlertsSyntheticsConditionApi();
 
-    private final PolicyItemApi<AlertsSyntheticsCondition> alertsSyntheticsConditionApi;
+    KeyTransactionsApi getKeyTransactionsApi();
 
-    private final KeyTransactionsApi keyTransactionsApi;
+    DeploymentsApi getDeploymentsApi();
 
-    private final DeploymentsApi deploymentsApi;
+    ServersApi getServersApi();
 
-    private final ServersApi serversApi;
+    UsersApi getUsersApi();
 
-    private final UsersApi usersApi;
+    DashboardsApi getDashboardsApi();
 
-    private final DashboardsApi dashboardsApi;
-
-    private final SyntheticsMonitorsApi syntheticsMonitorsApi;
-
-    /**
-     * NewRelic API constructor.
-     *
-     * @param apiKey API Key for given NewRelic account
-     */
-    public NewRelicApi(String apiKey) {
-        this(REST_API_URL, SYNTHETICS_URL, apiKey);
-    }
-
-    /**
-     * NewRelic API constructor.
-     *
-     * @param clientFactory    NewRelic client factory
-     */
-    public NewRelicApi(NewRelicClientFactory clientFactory) {
-        this(REST_API_URL, SYNTHETICS_URL, clientFactory);
-    }
-
-    /**
-     * NewRelic API constructor.
-     *
-     * @param restApiUrl NewRelic REST API URL, for example https://api.newrelic.com
-     * @param syntheticsApiUrl NewRelic Synthetics API URL
-     * @param apiKey  API Key for given NewRelic account
-     */
-    public NewRelicApi(String restApiUrl, String syntheticsApiUrl, String apiKey) {
-        this(restApiUrl, syntheticsApiUrl, new NewRelicClientFactory(apiKey));
-    }
-
-    /**
-     * NewRelic API constructor.
-     *
-     * @param restApiUrl NewRelic REST API URL, for example https://api.newrelic.com
-     * @param syntheticsApiUrl NewRelic Synthetics API URL
-     * @param clientFactory    NewRelic client factory
-     */
-    public NewRelicApi(String restApiUrl, String syntheticsApiUrl, NewRelicClientFactory clientFactory) {
-        NewRelicInternalApi internalApi = new NewRelicInternalApi(restApiUrl, syntheticsApiUrl, clientFactory);
-        applicationsApi = internalApi.getApplicationsApi();
-        alertsChannelsApi = internalApi.getAlertsChannelsApi();
-        alertsPoliciesApi = internalApi.getAlertsPoliciesApi();
-        alertsConditionsApi = internalApi.getAlertsConditionsApi();
-        alertsExternalServiceConditionsApi = internalApi.getAlertsExternalServiceConditionsApi();
-        alertsNrqlConditionsApi = internalApi.getAlertsNrqlConditionsApi();
-        alertsSyntheticsConditionApi = internalApi.getAlertsSyntheticsConditionApi();
-        keyTransactionsApi = internalApi.getKeyTransactionsApi();
-        deploymentsApi = internalApi.getDeploymentsApi();
-        serversApi = internalApi.getServersApi();
-        usersApi = internalApi.getUsersApi();
-        dashboardsApi = internalApi.getDashboardsApi();
-        syntheticsMonitorsApi = internalApi.getSyntheticsMonitorsApi();
-    }
+    SyntheticsMonitorsApi getSyntheticsMonitorsApi();
 }

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/NewRelicRestApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/NewRelicRestApi.java
@@ -1,0 +1,89 @@
+package com.ocadotechnology.newrelic.apiclient;
+
+import com.ocadotechnology.newrelic.apiclient.internal.NewRelicInternalApi;
+import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClientFactory;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.AlertsCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.external.AlertsExternalServiceCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.synthetics.AlertsSyntheticsCondition;
+import lombok.Getter;
+
+/**
+ * API facade - object exposing NewRelic REST API endpoints as Java methods. Requires API key.
+ */
+@Getter
+public class NewRelicRestApi implements NewRelicApi {
+
+    private static final String REST_API_URL = "https://api.newrelic.com";
+    private static final String SYNTHETICS_URL = "https://synthetics.newrelic.com/synthetics/api";
+
+    private final ApplicationsApi applicationsApi;
+
+    private final AlertsChannelsApi alertsChannelsApi;
+
+    private final AlertsPoliciesApi alertsPoliciesApi;
+
+    private final PolicyItemApi<AlertsCondition> alertsConditionsApi;
+
+    private final PolicyItemApi<AlertsNrqlCondition> alertsNrqlConditionsApi;
+
+    private final PolicyItemApi<AlertsExternalServiceCondition> alertsExternalServiceConditionsApi;
+
+    private final PolicyItemApi<AlertsSyntheticsCondition> alertsSyntheticsConditionApi;
+
+    private final KeyTransactionsApi keyTransactionsApi;
+
+    private final DeploymentsApi deploymentsApi;
+
+    private final ServersApi serversApi;
+
+    private final UsersApi usersApi;
+
+    private final DashboardsApi dashboardsApi;
+
+    private final SyntheticsMonitorsApi syntheticsMonitorsApi;
+
+    /**
+     * NewRelic REST API constructor.
+     *
+     * @param apiKey API Key for given NewRelic account
+     */
+    public NewRelicRestApi(String apiKey) {
+        this(REST_API_URL, SYNTHETICS_URL, apiKey);
+    }
+
+    /**
+     * NewRelic REST API constructor.
+     *
+     * @param restApiUrl NewRelic REST API URL, for example https://api.newrelic.com
+     * @param syntheticsApiUrl NewRelic Synthetics API URL
+     * @param apiKey  API Key for given NewRelic account
+     */
+    public NewRelicRestApi(String restApiUrl, String syntheticsApiUrl, String apiKey) {
+        this(restApiUrl, syntheticsApiUrl, new NewRelicClientFactory(apiKey));
+    }
+
+    /**
+     * NewRelic REST API constructor.
+     *
+     * @param restApiUrl NewRelic REST API URL, for example https://api.newrelic.com
+     * @param syntheticsApiUrl NewRelic Synthetics API URL
+     * @param clientFactory    NewRelic client factory
+     */
+    public NewRelicRestApi(String restApiUrl, String syntheticsApiUrl, NewRelicClientFactory clientFactory) {
+        NewRelicInternalApi internalApi = new NewRelicInternalApi(restApiUrl, syntheticsApiUrl, clientFactory);
+        applicationsApi = internalApi.getApplicationsApi();
+        alertsChannelsApi = internalApi.getAlertsChannelsApi();
+        alertsPoliciesApi = internalApi.getAlertsPoliciesApi();
+        alertsConditionsApi = internalApi.getAlertsConditionsApi();
+        alertsExternalServiceConditionsApi = internalApi.getAlertsExternalServiceConditionsApi();
+        alertsNrqlConditionsApi = internalApi.getAlertsNrqlConditionsApi();
+        alertsSyntheticsConditionApi = internalApi.getAlertsSyntheticsConditionApi();
+        keyTransactionsApi = internalApi.getKeyTransactionsApi();
+        deploymentsApi = internalApi.getDeploymentsApi();
+        serversApi = internalApi.getServersApi();
+        usersApi = internalApi.getUsersApi();
+        dashboardsApi = internalApi.getDashboardsApi();
+        syntheticsMonitorsApi = internalApi.getSyntheticsMonitorsApi();
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/PolicyItemApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/PolicyItemApi.java
@@ -35,5 +35,5 @@ public interface PolicyItemApi<T> {
      * @param id id of the item to be deleted
      * @return deleted {@link T}
      */
-    T delete(int id);
+    T delete(int policyId, int id);
 }

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsChannelsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsChannelsApi.java
@@ -11,13 +11,13 @@ import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
-class DefaultAlertsChannelsApi extends ApiBase implements AlertsChannelsApi {
+public class DefaultAlertsChannelsApi extends ApiBase implements AlertsChannelsApi {
 
     private static final String CHANNELS_URL = "/v2/alerts_channels.json";
     private static final String CHANNEL_URL = "/v2/alerts_channels/{channel_id}.json";
     private static final String POLICY_CHANNELS_URL = "/v2/alerts_policy_channels.json";
 
-    DefaultAlertsChannelsApi(NewRelicClient client) {
+    public DefaultAlertsChannelsApi(NewRelicClient client) {
         super(client);
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsConditionsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsConditionsApi.java
@@ -11,13 +11,13 @@ import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
-class DefaultAlertsConditionsApi extends ApiBase implements PolicyItemApi<AlertsCondition> {
+public class DefaultAlertsConditionsApi extends ApiBase implements PolicyItemApi<AlertsCondition> {
 
     private static final String CONDITIONS_URL = "/v2/alerts_conditions";
     private static final String CONDITION_URL = "/v2/alerts_conditions/{condition_id}.json";
     private static final String CONDITION_POLICY_URL = "/v2/alerts_conditions/policies/{policy_id}.json";
 
-    DefaultAlertsConditionsApi(NewRelicClient client) {
+    public DefaultAlertsConditionsApi(NewRelicClient client) {
         super(client);
     }
 
@@ -52,7 +52,7 @@ class DefaultAlertsConditionsApi extends ApiBase implements PolicyItemApi<Alerts
     }
 
     @Override
-    public AlertsCondition delete(int conditionId) {
+    public AlertsCondition delete(int policyId, int conditionId) {
         return client
                 .target(CONDITION_URL)
                 .resolveTemplate("condition_id", conditionId)

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsExternalServiceConditionsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsExternalServiceConditionsApi.java
@@ -11,13 +11,13 @@ import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
-class DefaultAlertsExternalServiceConditionsApi extends ApiBase implements PolicyItemApi<AlertsExternalServiceCondition> {
+public class DefaultAlertsExternalServiceConditionsApi extends ApiBase implements PolicyItemApi<AlertsExternalServiceCondition> {
 
     private static final String CONDITIONS_URL = "/v2/alerts_external_service_conditions";
     private static final String CONDITION_URL = "/v2/alerts_external_service_conditions/{condition_id}.json";
     private static final String CONDITION_POLICY_URL = "/v2/alerts_external_service_conditions/policies/{policy_id}.json";
 
-    DefaultAlertsExternalServiceConditionsApi(NewRelicClient client) {
+    public DefaultAlertsExternalServiceConditionsApi(NewRelicClient client) {
         super(client);
     }
 
@@ -52,7 +52,7 @@ class DefaultAlertsExternalServiceConditionsApi extends ApiBase implements Polic
     }
 
     @Override
-    public AlertsExternalServiceCondition delete(int conditionId) {
+    public AlertsExternalServiceCondition delete(int policyId, int conditionId) {
         return client
                 .target(CONDITION_URL)
                 .resolveTemplate("condition_id", conditionId)

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsNrqlConditionsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsNrqlConditionsApi.java
@@ -11,13 +11,13 @@ import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
-class DefaultAlertsNrqlConditionsApi extends ApiBase implements PolicyItemApi<AlertsNrqlCondition> {
+public class DefaultAlertsNrqlConditionsApi extends ApiBase implements PolicyItemApi<AlertsNrqlCondition> {
 
     private static final String CONDITIONS_URL = "/v2/alerts_nrql_conditions.json";
     private static final String CONDITION_URL = "/v2/alerts_nrql_conditions/{condition_id}.json";
     private static final String CONDITION_POLICY_URL = "/v2/alerts_nrql_conditions/policies/{policy_id}.json";
 
-    DefaultAlertsNrqlConditionsApi(NewRelicClient client) {
+    public DefaultAlertsNrqlConditionsApi(NewRelicClient client) {
         super(client);
     }
 
@@ -52,7 +52,7 @@ class DefaultAlertsNrqlConditionsApi extends ApiBase implements PolicyItemApi<Al
     }
 
     @Override
-    public AlertsNrqlCondition delete(int conditionId) {
+    public AlertsNrqlCondition delete(int policyId, int conditionId) {
         return client
                 .target(CONDITION_URL)
                 .resolveTemplate("condition_id", conditionId)

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsPoliciesApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsPoliciesApi.java
@@ -17,13 +17,13 @@ import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
-class DefaultAlertsPoliciesApi extends ApiBase implements AlertsPoliciesApi {
+public class DefaultAlertsPoliciesApi extends ApiBase implements AlertsPoliciesApi {
 
     private static final String POLICIES_URL = "/v2/alerts_policies.json";
     private static final String POLICY_URL = "/v2/alerts_policies/{policy_id}.json";
     private static final String POLICY_CHANNELS_URL = "/v2/alerts_policy_channels.json";
 
-    DefaultAlertsPoliciesApi(NewRelicClient client) {
+    public DefaultAlertsPoliciesApi(NewRelicClient client) {
         super(client);
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsSyntheticsConditionsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultAlertsSyntheticsConditionsApi.java
@@ -1,24 +1,23 @@
 package com.ocadotechnology.newrelic.apiclient.internal;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
-
-import java.util.List;
-
-import javax.ws.rs.client.Entity;
-
 import com.ocadotechnology.newrelic.apiclient.PolicyItemApi;
 import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClient;
 import com.ocadotechnology.newrelic.apiclient.internal.model.AlertsSyntheticsConditionList;
 import com.ocadotechnology.newrelic.apiclient.internal.model.AlertsSyntheticsConditionWrapper;
 import com.ocadotechnology.newrelic.apiclient.model.conditions.synthetics.AlertsSyntheticsCondition;
 
-class DefaultAlertsSyntheticsConditionsApi extends ApiBase implements PolicyItemApi<AlertsSyntheticsCondition> {
+import javax.ws.rs.client.Entity;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+public class DefaultAlertsSyntheticsConditionsApi extends ApiBase implements PolicyItemApi<AlertsSyntheticsCondition> {
 
     private static final String CONDITIONS_URL = "/v2/alerts_synthetics_conditions";
     private static final String CONDITION_URL = "/v2/alerts_synthetics_conditions/{condition_id}.json";
     private static final String CONDITION_POLICY_URL = "/v2/alerts_synthetics_conditions/policies/{policy_id}.json";
 
-    DefaultAlertsSyntheticsConditionsApi(NewRelicClient client) {
+    public DefaultAlertsSyntheticsConditionsApi(NewRelicClient client) {
         super(client);
     }
 
@@ -53,7 +52,7 @@ class DefaultAlertsSyntheticsConditionsApi extends ApiBase implements PolicyItem
     }
 
     @Override
-    public AlertsSyntheticsCondition delete(int conditionId) {
+    public AlertsSyntheticsCondition delete(int policyId, int conditionId) {
         return client
                 .target(CONDITION_URL)
                 .resolveTemplate("condition_id", conditionId)

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultApplicationsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultApplicationsApi.java
@@ -12,12 +12,12 @@ import java.util.Optional;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
-class DefaultApplicationsApi extends ApiBase implements ApplicationsApi {
+public class DefaultApplicationsApi extends ApiBase implements ApplicationsApi {
 
     private static final String APPLICATIONS_URL = "/v2/applications.json";
     private static final String APPLICATION_URL = "/v2/applications/{application_id}.json";
 
-    DefaultApplicationsApi(NewRelicClient client) {
+    public DefaultApplicationsApi(NewRelicClient client) {
         super(client);
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDashboardsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDashboardsApi.java
@@ -15,13 +15,13 @@ import java.util.List;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.glassfish.jersey.uri.UriComponent.Type.QUERY_PARAM_SPACE_ENCODED;
 
-class DefaultDashboardsApi extends ApiBase implements DashboardsApi {
+public class DefaultDashboardsApi extends ApiBase implements DashboardsApi {
 
     private static final String DASHBOARDS_URL = "/v2/dashboards.json";
 
     private static final String DASHBOARD_URL = "/v2/dashboards/{dashboard_id}.json";
 
-    DefaultDashboardsApi(NewRelicClient client) {
+    public DefaultDashboardsApi(NewRelicClient client) {
         super(client);
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDeploymentsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultDeploymentsApi.java
@@ -11,12 +11,12 @@ import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
-class DefaultDeploymentsApi extends ApiBase implements DeploymentsApi {
+public class DefaultDeploymentsApi extends ApiBase implements DeploymentsApi {
 
     private static final String DEPLOYMENTS_URL = "/v2/applications/{application_id}/deployments.json";
     private static final String DEPLOYMENT_URL = "/v2/applications/{application_id}/deployments/{deployment_id}.json";
 
-    DefaultDeploymentsApi(NewRelicClient client) {
+    public DefaultDeploymentsApi(NewRelicClient client) {
         super(client);
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultKeyTransactionsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultKeyTransactionsApi.java
@@ -12,12 +12,12 @@ import java.util.Optional;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.glassfish.jersey.uri.UriComponent.Type.QUERY_PARAM_SPACE_ENCODED;
 
-class DefaultKeyTransactionsApi extends ApiBase implements KeyTransactionsApi {
+public class DefaultKeyTransactionsApi extends ApiBase implements KeyTransactionsApi {
 
     private static final String KEY_TRANSACTIONS_URL = "/v2/key_transactions.json";
     private static final String KEY_TRANSACTION_URL = "/v2/key_transactions/{key_transaction_id}.json";
 
-    DefaultKeyTransactionsApi(NewRelicClient client) {
+    public DefaultKeyTransactionsApi(NewRelicClient client) {
         super(client);
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultServersApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultServersApi.java
@@ -14,11 +14,11 @@ import java.util.Optional;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.glassfish.jersey.uri.UriComponent.Type.QUERY_PARAM_SPACE_ENCODED;
 
-class DefaultServersApi extends ApiBase implements ServersApi {
+public class DefaultServersApi extends ApiBase implements ServersApi {
     private static final String SERVERS_URL = "/v2/servers.json";
     private static final String SERVER_URL = "/v2/servers/{server_id}.json";
 
-    DefaultServersApi(NewRelicClient client) {
+    public DefaultServersApi(NewRelicClient client) {
         super(client);
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultSyntheticsMonitorsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultSyntheticsMonitorsApi.java
@@ -4,18 +4,19 @@ import com.ocadotechnology.newrelic.apiclient.SyntheticsMonitorsApi;
 import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClient;
 import com.ocadotechnology.newrelic.apiclient.internal.model.MonitorList;
 import com.ocadotechnology.newrelic.apiclient.model.synthetics.Monitor;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Response;
 import java.util.Optional;
 
-class DefaultSyntheticsMonitorsApi extends ApiBase implements SyntheticsMonitorsApi {
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+public class DefaultSyntheticsMonitorsApi extends ApiBase implements SyntheticsMonitorsApi {
 
     private static final String MONITORS_URL = "/v3/monitors";
 
-    DefaultSyntheticsMonitorsApi(NewRelicClient client) {
+    public DefaultSyntheticsMonitorsApi(NewRelicClient client) {
         super(client);
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultUsersApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/internal/DefaultUsersApi.java
@@ -14,11 +14,11 @@ import java.util.Optional;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.glassfish.jersey.uri.UriComponent.Type.QUERY_PARAM_SPACE_ENCODED;
 
-class DefaultUsersApi extends ApiBase implements UsersApi {
+public class DefaultUsersApi extends ApiBase implements UsersApi {
     private static final String USERS_URL = "/v2/users.json";
     private static final String USER_URL = "/v2/users/{user_id}.json";
 
-    DefaultUsersApi(NewRelicClient client) {
+    public DefaultUsersApi(NewRelicClient client) {
         super(client);
     }
 

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/policies/AlertsPolicy.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/apiclient/model/policies/AlertsPolicy.java
@@ -1,5 +1,6 @@
 package com.ocadotechnology.newrelic.apiclient.model.policies;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ public class AlertsPolicy {
     @JsonProperty
     Integer id;
     @JsonProperty("incident_preference")
+    @JsonAlias({"incidentPreference"})
     String incidentPreference;
     @JsonProperty
     String name;

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/GraphqlApiError.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/GraphqlApiError.java
@@ -1,0 +1,11 @@
+package com.ocadotechnology.newrelic.graphql.apiclient;
+
+public class GraphqlApiError extends RuntimeException {
+    public GraphqlApiError(String message) {
+        super(message);
+    }
+
+    public GraphqlApiError(Throwable cause) {
+        super(cause);
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/NewRelicHybridApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/NewRelicHybridApi.java
@@ -1,0 +1,98 @@
+package com.ocadotechnology.newrelic.graphql.apiclient;
+
+import com.ocadotechnology.newrelic.apiclient.*;
+import com.ocadotechnology.newrelic.apiclient.internal.*;
+import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClient;
+import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClientFactory;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.AlertsCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.external.AlertsExternalServiceCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.synthetics.AlertsSyntheticsCondition;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.*;
+import lombok.Getter;
+
+/**
+ * API facade - object exposing NewRelic GraphQL API as Java methods. Requires API key and NewRelic account id.
+ */
+@Getter
+public class NewRelicHybridApi implements NewRelicApi {
+    private static final String GRAPHQL_API_URL = "https://api.newrelic.com/graphql";
+    private static final String REST_API_URL = "https://api.newrelic.com";
+
+    private static final String SYNTHETICS_URL = "https://synthetics.newrelic.com/synthetics/api";
+
+    private final ApplicationsApi applicationsApi;
+
+    private final AlertsChannelsApi alertsChannelsApi;
+
+    private final AlertsPoliciesApi alertsPoliciesApi;
+
+    private final PolicyItemApi<AlertsCondition> alertsConditionsApi;
+
+    private final PolicyItemApi<AlertsNrqlCondition> alertsNrqlConditionsApi;
+
+    private final PolicyItemApi<AlertsExternalServiceCondition> alertsExternalServiceConditionsApi;
+
+    private final PolicyItemApi<AlertsSyntheticsCondition> alertsSyntheticsConditionApi;
+
+    private final KeyTransactionsApi keyTransactionsApi;
+
+    private final DeploymentsApi deploymentsApi;
+
+    private final ServersApi serversApi;
+
+    private final UsersApi usersApi;
+
+    private final DashboardsApi dashboardsApi;
+
+    private final SyntheticsMonitorsApi syntheticsMonitorsApi;
+
+    /**
+     * NewRelic Hybrid API constructor.
+     *
+     * @param apiKey           API Key for given NewRelic account
+     * @param accountId        NewRelic account id
+     */
+    public NewRelicHybridApi(String apiKey, long accountId) {
+        this(GRAPHQL_API_URL, REST_API_URL, SYNTHETICS_URL, new NewRelicClientFactory(apiKey), accountId);
+    }
+
+    /**
+     * NewRelic Hybrid API constructor.
+     *
+     * @param graphqlApiUrl    NewRelic GRAPH QL API URL, for example https://api.newrelic.com/graphql
+     * @param restApiUrl       NewRelic REST API URL, for example https://api.newrelic.com
+     * @param syntheticsApiUrl NewRelic Synthetics API URL
+     * @param clientFactory    NewRelic client factory
+     * @param accountId        NewRelic account id
+     */
+    public NewRelicHybridApi(String graphqlApiUrl, String restApiUrl, String syntheticsApiUrl, NewRelicClientFactory clientFactory, long accountId) {
+        NewRelicClient graphqlClient = clientFactory.create(graphqlApiUrl);
+        NewRelicClient restClient = clientFactory.create(restApiUrl);
+        NewRelicClient syntheticsClient = clientFactory.create(syntheticsApiUrl);
+        DefaultQueryExecutor queryExecutor = new DefaultQueryExecutor(graphqlClient);
+        ModelTranslator modelTranslator = new ModelTranslator();
+
+        this.alertsChannelsApi = new GraphqlAlertsChannelsApi(queryExecutor, accountId, modelTranslator);
+        this.alertsPoliciesApi = new GraphqlAlertsPoliciesApi(queryExecutor, accountId);
+        this.alertsNrqlConditionsApi = new GraphqlAlertsNrqlConditionsApi(queryExecutor, accountId, modelTranslator);
+
+        // To be replaced by NRQL conditions
+        this.alertsConditionsApi = new DefaultAlertsConditionsApi(restClient);
+        this.alertsSyntheticsConditionApi = new DefaultAlertsSyntheticsConditionsApi(restClient);
+        this.alertsExternalServiceConditionsApi = new DefaultAlertsExternalServiceConditionsApi(restClient);
+
+        // Still valid rest API with no replacement
+        this.applicationsApi = new DefaultApplicationsApi(restClient);
+        this.keyTransactionsApi = new DefaultKeyTransactionsApi(restClient);
+        this.deploymentsApi = new DefaultDeploymentsApi(restClient);
+
+        // To be deleted
+        this.serversApi = new DefaultServersApi(restClient);
+        this.usersApi = new DefaultUsersApi(restClient);
+        this.dashboardsApi = new DefaultDashboardsApi(restClient);
+
+        // To be replaced but with changes
+        this.syntheticsMonitorsApi = new DefaultSyntheticsMonitorsApi(syntheticsClient);
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/ApiBase.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/ApiBase.java
@@ -1,0 +1,99 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.k0kubun.builder.query.graphql.GraphQLQueryBuilder;
+import com.github.k0kubun.builder.query.graphql.builder.ObjectBuilder;
+import com.github.k0kubun.builder.query.graphql.model.GraphQLObject;
+import com.ocadotechnology.newrelic.graphql.apiclient.GraphqlApiError;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Result;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.mutation.MutationResult;
+import lombok.RequiredArgsConstructor;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static com.fasterxml.jackson.core.json.JsonWriteFeature.QUOTE_FIELD_NAMES;
+
+@RequiredArgsConstructor
+public abstract class ApiBase {
+    private final QueryExecutor executor;
+
+    protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .disable(QUOTE_FIELD_NAMES.mappedFeature())
+            .setSerializationInclusion(NON_NULL);
+
+    protected Result execute(Query query) {
+        return executor.execute(query);
+    }
+
+    protected GraphQLObject object(UnaryOperator<ObjectBuilder> custom) {
+        return custom.apply(GraphQLQueryBuilder.object()).build();
+    }
+
+
+    protected Map<String, Object> params(String name1, Object value1, String name2, Object value2) {
+        Map<String, Object> params = param(name1, value1);
+        params.put(name2, value2);
+        return params;
+    }
+
+    protected Map<String, Object> params(String name1, Object value1, String name2, Object value2, String name3, Object value3) {
+        Map<String, Object> params = params(name1, value1, name2, value2);
+        params.put(name3, value3);
+        return params;
+    }
+
+    protected ParamValueWrapper complexParamValue(Map<String, Object> props) {
+        try {
+            return new ParamValueWrapper(OBJECT_MAPPER.writeValueAsString(props));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected Map<String, Object> param(String name, Object value) {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put(name, value);
+        return params;
+    }
+
+    protected Result throwOnError(Result result) {
+        if (result.hasErrors()) {
+            throw new GraphqlApiError(result.getErrors().toString());
+        }
+        return result;
+    }
+
+    protected <T> Optional<T> throwOnError(Result result, Function<Result, Optional<? extends MutationResult<T>>> resultGetter) {
+        return resultGetter.apply(throwOnError(result))
+                .map(r -> {
+                    if (r.hasErrors()) {
+                        throw new GraphqlApiError(r.getErrors().toString());
+                    }
+                    return r.get();
+                });
+    }
+
+    protected <T> Stream<T> asStream(Iterator<T> sourceIterator) {
+        return StreamSupport.stream(((Iterable<T>) () -> sourceIterator).spliterator(), false);
+    }
+
+    @RequiredArgsConstructor
+    protected static class ParamValueWrapper {
+        private final String value;
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/DefaultQueryExecutor.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/DefaultQueryExecutor.java
@@ -1,0 +1,23 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.ocadotechnology.newrelic.apiclient.internal.client.NewRelicClient;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Result;
+import lombok.RequiredArgsConstructor;
+
+import javax.ws.rs.client.Entity;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+@RequiredArgsConstructor
+public class DefaultQueryExecutor implements QueryExecutor {
+    private final NewRelicClient client;
+    @Override
+    public Result execute(Query query) {
+        return client.target("")
+                .request(APPLICATION_JSON_TYPE)
+                .buildPost(Entity.entity(query, APPLICATION_JSON_TYPE))
+                .invoke()
+                .readEntity(Result.class);
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsChannelsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsChannelsApi.java
@@ -1,0 +1,217 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.github.k0kubun.builder.query.graphql.builder.ObjectBuilder;
+import com.github.k0kubun.builder.query.graphql.model.GraphQLObject;
+import com.ocadotechnology.newrelic.apiclient.AlertsChannelsApi;
+import com.ocadotechnology.newrelic.apiclient.model.channels.AlertsChannel;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.NotificationChannels;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.PageIterator;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Result;
+import lombok.SneakyThrows;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.github.k0kubun.builder.query.graphql.GraphQLQueryBuilder.query;
+import static java.util.stream.Collectors.toList;
+
+public class GraphqlAlertsChannelsApi extends ApiBase implements AlertsChannelsApi {
+    private final long accountId;
+    private final ModelTranslator modelTranslator;
+
+    public GraphqlAlertsChannelsApi(QueryExecutor executor, long accountId) {
+        super(executor);
+        this.accountId = accountId;
+        this.modelTranslator = new ModelTranslator();
+    }
+
+    public GraphqlAlertsChannelsApi(QueryExecutor executor, long accountId, ModelTranslator modelTranslator) {
+        super(executor);
+        this.accountId = accountId;
+        this.modelTranslator = modelTranslator;
+    }
+
+    @Override
+    public List<AlertsChannel> list() {
+        return asStream(new PageIterator<>(this::fetchListPage))
+                .flatMap(Collection::stream)
+                .map(modelTranslator::toModel)
+                .collect(toList());
+    }
+
+    private Optional<NotificationChannels> fetchListPage(String cursor) {
+        String query = query()
+                .object("actor", object(actor -> actor
+                        .object("account", param("id", accountId), object(account -> account
+                                .object("alerts", object(alerts -> alerts
+                                        .object("notificationChannels", param("cursor", cursor),
+                                                object(notificationChannels -> notificationChannels
+                                                        .field("nextCursor")
+                                                        .object("channels", notificationChannelSchema())
+                                                )))))))).build();
+
+        return throwOnError(execute(Query.wrapped(query))).getNotificationChannels();
+    }
+
+    @Override
+    @SneakyThrows
+    public AlertsChannel create(AlertsChannel channel) {
+        Map<String, Object> channelConfig = modelTranslator.toChannelConfig(channel.getType(), channel.getName(), channel.getConfiguration());
+        String query = query()
+                .object("mutation",
+                        object(mutation -> mutation.object(
+                                "alertsNotificationChannelCreate",
+                                params(
+                                        "accountId", accountId,
+                                        "notificationChannel", complexParamValue(channelConfig)),
+                                object(alertsNotificationChannelCreate -> alertsNotificationChannelCreate
+                                        .object("error", object(errors -> errors
+                                                .field("description")
+                                                .field("errorType")
+                                        ))
+                                        .object("notificationChannel",
+                                                object(notificationChannel -> notificationChannel
+                                                        .on("AlertsEmailNotificationChannel",
+                                                                object(ch -> channelSpec(ch, emailConfig())))
+                                                        .on("AlertsPagerDutyNotificationChannel",
+                                                                object(ch -> channelSpec(ch, pagerDutyConfig())))
+                                                        .on("AlertsSlackNotificationChannel",
+                                                                object(ch -> channelSpec(ch, slackConfig())))
+                                                        .on("AlertsWebhookNotificationChannel",
+                                                                object(ch -> channelSpec(ch, webhookConfig())))))))))
+                .build();
+
+        return throwOnError(execute(Query.of(query)), Result::getAlertsNotificationChannelCreate).map(modelTranslator::toModel).get();
+    }
+
+    private ObjectBuilder channelSpec(ObjectBuilder channel, GraphQLObject config) {
+        return channel
+                .field("id")
+                .field("name")
+                .field("type")
+                .object("config", config)
+                .object("associatedPolicies", object(associatedPolicies -> associatedPolicies
+                        .object("policies", object(policies -> policies
+                                .field("id")))));
+    }
+
+    @Override
+    public AlertsChannel delete(int channelId) {
+        AlertsChannel channel = throwOnError(doGetById(channelId)).getNotificationChannel()
+                .map(modelTranslator::toModel).get();
+
+        String query = query()
+                .object("mutation",
+                        object(mutation -> mutation.object(
+                                "alertsNotificationChannelDelete",
+                                params("accountId", accountId, "id", "" + channelId),
+                                object(alertsNotificationChannelDelete -> alertsNotificationChannelDelete
+                                        .object("error", object(error -> error
+                                                .field("description")
+                                                .field("errorType")
+                                                .field("notificationChannelId")))))))
+                .build();
+
+        throwOnError(execute(Query.of(query)), Result::getAlertsNotificationChannelDelete);
+        return channel;
+    }
+
+    @Override
+    public AlertsChannel deleteFromPolicy(int policyId, int channelId) {
+        AlertsChannel channel = throwOnError(doGetById(channelId)).getNotificationChannel()
+                .map(modelTranslator::toModel).get();
+
+        String query = query()
+                .object("mutation",
+                        object(mutation -> mutation.object(
+                                "alertsNotificationChannelsRemoveFromPolicy",
+                                params(
+                                        "accountId", accountId,
+                                        "policyId", "" + policyId,
+                                        "notificationChannelIds", "" + channelId),
+                                object(alertsNotificationChannelsRemoveFromPolicy -> alertsNotificationChannelsRemoveFromPolicy
+                                        .object("notificationChannels", object(notificationChannels -> notificationChannels
+                                                .field("id")))
+                                        .object("errors", object(errors -> errors
+                                                .field("description")
+                                                .field("errorType")
+                                                .field("notificationChannelId")))))))
+                .build();
+
+        throwOnError(execute(Query.of(query)), Result::getAlertsNotificationChannelsRemoveFromPolicy);
+        return channel;
+    }
+
+    public Optional<AlertsChannel> getById(int channelId) {
+        return getChannel(doGetById(channelId));
+    }
+
+    private Result doGetById(int channelId) {
+        String query = query()
+                .object("actor", object(actor -> actor
+                        .object("account", param("id", accountId), object(account -> account
+                                .object("alerts", object(alerts -> alerts
+                                        .object("notificationChannel", param("id", "" + channelId), notificationChannelSchema()))))))).build();
+        return execute(Query.wrapped(query));
+    }
+
+    private GraphQLObject notificationChannelSchema() {
+        return object(notificationChannel -> notificationChannel
+                .field("id")
+                .field("name")
+                .field("type")
+                .object("associatedPolicies", object(associatedPolicies -> associatedPolicies.object("policies", object(policies -> policies
+                        .field("id")))))
+                .on("AlertsEmailNotificationChannel", object(channel -> channel
+                        .object("config", emailConfig())))
+                .on("AlertsSlackNotificationChannel", object(channel -> channel
+                        .object("config", slackConfig())))
+                .on("AlertsPagerDutyNotificationChannel", object(channel -> channel
+                        .object("config", pagerDutyConfig())))
+                .on("AlertsWebhookNotificationChannel", object(channel -> channel
+                        .object("config", webhookConfig())))
+                .on("AlertsUserNotificationChannel", object(channel -> channel
+                        .object("config", object(config -> config
+                                .field("userId")))))
+        );
+    }
+
+    private Optional<AlertsChannel> getChannel(Result result) {
+        return result.notFound()
+                ? Optional.empty()
+                : throwOnError(result).getNotificationChannel().map(modelTranslator::toModel);
+    }
+
+    private GraphQLObject emailConfig() {
+        return object(config -> config
+                .field("emails")
+                .field("includeJson"));
+    }
+
+    private GraphQLObject slackConfig() {
+        return object(config -> config
+                .field("teamChannel")
+                .field("url"));
+    }
+
+    private GraphQLObject pagerDutyConfig() {
+        return object(config -> config
+                .field("apiKey"));
+    }
+
+    private GraphQLObject webhookConfig() {
+        return object(config -> config
+                .field("baseUrl")
+                .object("basicAuth", object(basicAuth -> basicAuth
+                        .field("username")
+                        .field("password")))
+                .object("customHttpHeaders", object(headers -> headers
+                        .field("name")
+                        .field("value")))
+                .field("customPayloadBody")
+                .field("customPayloadType"));
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsNrqlConditionsApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsNrqlConditionsApi.java
@@ -1,0 +1,163 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.github.k0kubun.builder.query.graphql.builder.ObjectBuilder;
+import com.ocadotechnology.newrelic.apiclient.PolicyItemApi;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
+import com.ocadotechnology.newrelic.graphql.apiclient.GraphqlApiError;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.NrqlCondition;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.NrqlConditionsSearch;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.PageIterator;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static com.github.k0kubun.builder.query.graphql.GraphQLQueryBuilder.query;
+import static com.ocadotechnology.newrelic.graphql.apiclient.internal.util.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toList;
+
+public class GraphqlAlertsNrqlConditionsApi extends ApiBase implements PolicyItemApi<AlertsNrqlCondition> {
+    private final long accountId;
+    private final ModelTranslator modelTranslator;
+
+    public GraphqlAlertsNrqlConditionsApi(QueryExecutor executor, long accountId) {
+        super(executor);
+        this.accountId = accountId;
+        this.modelTranslator = new ModelTranslator();
+    }
+
+    public GraphqlAlertsNrqlConditionsApi(QueryExecutor executor, long accountId, ModelTranslator modelTranslator) {
+        super(executor);
+        this.accountId = accountId;
+        this.modelTranslator = modelTranslator;
+    }
+
+    @Override
+    public List<AlertsNrqlCondition> list(int policyId) {
+        return doList(policyId)
+                .map(modelTranslator::toModel)
+                .collect(toList());
+    }
+
+    private Stream<NrqlCondition> doList(int policyId) {
+        return asStream(new PageIterator<>(cursor -> fetchListPage(policyId, cursor)))
+                .flatMap(Collection::stream);
+    }
+
+    private Optional<NrqlConditionsSearch> fetchListPage(int policyId, String cursor) {
+        String query = query()
+                .object("actor", object(actor -> actor
+                        .object("account", param("id", accountId), object(account -> account
+                                .object("alerts", object(alerts -> alerts
+                                        .object("nrqlConditionsSearch", params(
+                                                        "cursor", cursor, "searchCriteria",
+                                                        complexParamValue(param("policyId", policyId))),
+                                                object(notificationChannels -> notificationChannels
+                                                        .field("nextCursor")
+                                                        .object("nrqlConditions",
+                                                                object(nrqlCondition()))
+                                                ))))))
+                )).build();
+
+        return throwOnError(execute(Query.wrapped(query))).getNrqlConditionsSearch();
+    }
+
+    private UnaryOperator<ObjectBuilder> nrqlCondition() {
+        return nrqlCondition -> nrqlCondition
+                .field("id")
+                .field("name")
+                .field("enabled")
+                .field("runbookUrl")
+                .object("nrql",
+                        object(nrql -> nrql.field("query")))
+                .object("signal",
+                        object(signal -> signal
+                                .field("aggregationDelay")
+                                .field("aggregationMethod")
+                                .field("aggregationTimer")
+                                .field("aggregationWindow")
+                                .field("evaluationDelay")
+                                .field("fillOption")
+                                .field("fillValue")
+                                .field("slideBy")))
+                .object("terms",
+                        object(terms -> terms
+                                .field("operator")
+                                .field("priority")
+                                .field("threshold")
+                                .field("thresholdDuration")
+                                .field("thresholdOccurrences")))
+                .object("expiration", object(expiration -> expiration
+                        .field("closeViolationsOnExpiration")
+                        .field("expirationDuration")
+                        .field("openViolationOnExpiration")
+                ))
+                .on("AlertsNrqlStaticCondition",
+                        object(staticCondition -> staticCondition
+                                .field("valueFunction")));
+    }
+
+    @Override
+    public AlertsNrqlCondition create(int policyId, AlertsNrqlCondition condition) {
+        checkArgument(nonNull(condition), "condition must not be null");
+        checkArgument(nonNull(condition.getName()), "name must not be null");
+
+        String query = query()
+                .object("mutation",
+                        object(mutation -> mutation.object(
+                                "alertsNrqlConditionStaticCreate",
+                                params(
+                                        "accountId", accountId,
+                                        "policyId", policyId,
+                                        "condition", complexParamValue(modelTranslator.toNrqlCondition(condition))),
+                                object(nrqlCondition())))).build();
+
+        return throwOnError(execute(Query.of(query))).getAlertsNrqlConditionStaticCreate().map(modelTranslator::toModel).get();
+    }
+
+    @Override
+    public AlertsNrqlCondition update(int conditionId, AlertsNrqlCondition condition) {
+        checkArgument(nonNull(condition), "condition must not be null");
+
+        String query = query()
+                .object("mutation",
+                        object(mutation -> mutation.object(
+                                "alertsNrqlConditionStaticUpdate",
+                                params(
+                                        "accountId", accountId,
+                                        "id", conditionId,
+                                        "condition", complexParamValue(modelTranslator.toNrqlCondition(condition))),
+                                object(nrqlCondition())))).build();
+
+        return throwOnError(execute(Query.of(query))).getAlertsNrqlConditionStaticUpdate().map(modelTranslator::toModel).get();
+    }
+
+    @Override
+    public AlertsNrqlCondition delete(int policyId, int conditionId) {
+        AlertsNrqlCondition condition = getCondition(policyId, conditionId)
+                .orElseThrow(() -> new GraphqlApiError(String.format("Condition %d not found in policy %d", conditionId, policyId)));
+
+        String query = query()
+                .object("mutation",
+                        object(mutation -> mutation.object(
+                                "alertsConditionDelete",
+                                params(
+                                        "accountId", accountId,
+                                        "id", conditionId),
+                                object(alertsConditionDelete -> alertsConditionDelete.field("id"))))).build();
+
+        throwOnError(execute(Query.of(query)));
+
+        return condition;
+    }
+
+    private Optional<AlertsNrqlCondition> getCondition(int policyId, int conditionId) {
+        return doList(policyId).filter(condition -> condition.getId().equals("" + conditionId))
+                .findFirst()
+                .map(modelTranslator::toModel);
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsPoliciesApi.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsPoliciesApi.java
@@ -1,0 +1,134 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.ocadotechnology.newrelic.apiclient.AlertsPoliciesApi;
+import com.ocadotechnology.newrelic.apiclient.model.policies.AlertsPolicy;
+import com.ocadotechnology.newrelic.apiclient.model.policies.AlertsPolicyChannels;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.JavaLikeEnum;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Result;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.github.k0kubun.builder.query.graphql.GraphQLQueryBuilder.query;
+import static com.ocadotechnology.newrelic.graphql.apiclient.internal.util.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
+
+public class GraphqlAlertsPoliciesApi extends ApiBase implements AlertsPoliciesApi {
+    private final long accountId;
+
+    public GraphqlAlertsPoliciesApi(QueryExecutor executor, long accountId) {
+        super(executor);
+        this.accountId = accountId;
+    }
+
+    @Override
+    public Optional<AlertsPolicy> getByName(String alertsPolicyName) {
+        String query = query()
+                .object("actor",
+                        object(actor -> actor.object("account", param("id", accountId),
+                                object(account -> account.object("alerts",
+                                        object(alerts -> alerts.object(
+                                                "policiesSearch",
+                                                param("searchCriteria", complexParamValue(param("name", alertsPolicyName))),
+                                                object(policiesSearch -> policiesSearch.object("policies", object(policies -> policies
+                                                        .field("id")
+                                                        .field("name")
+                                                        .field("incidentPreference"))))))))))).build();
+
+        List<AlertsPolicy> policies = execute(Query.wrapped(query)).getPolicies();
+        return policies.isEmpty() ? Optional.empty() : Optional.ofNullable(policies.get(0));
+    }
+
+    public Optional<AlertsPolicy> getById(int policyId) {
+        return getPolicy(doGetById(policyId));
+    }
+
+    private Result doGetById(int policyId) {
+        String query = query()
+                .object("actor",
+                        object(actor -> actor.object("account", param("id", accountId),
+                                object(account -> account.object("alerts",
+                                        object(alerts -> alerts.object("policy", param("id", policyId),
+                                                object(policy -> policy
+                                                        .field("id")
+                                                        .field("name")
+                                                        .field("incidentPreference"))))))))).build();
+
+        return execute(Query.wrapped(query));
+    }
+
+    private Optional<AlertsPolicy> getPolicy(Result result) {
+        return result.notFound() ? Optional.empty() : throwOnError(result).getAlertsPolicy();
+    }
+
+    @Override
+    public AlertsPolicy create(AlertsPolicy policy) {
+        checkArgument(nonNull(policy), "policy must not be null");
+        checkArgument(nonNull(policy.getName()), "name must not be null");
+        checkArgument(nonNull(policy.getIncidentPreference()), "incident preference must not be null");
+
+        String query = query()
+                .object("mutation",
+                        object(mutation -> mutation.object(
+                                "alertsPolicyCreate",
+                                params(
+                                        "accountId", accountId,
+                                        "policy", complexParamValue(params(
+                                                "name", policy.getName(),
+                                                "incidentPreference", new JavaLikeEnum(policy.getIncidentPreference())))),
+
+                                object(alertsPolicyCreate -> alertsPolicyCreate
+                                        .field("id")
+                                        .field("name")
+                                        .field("incidentPreference"))))).build();
+
+        return throwOnError(execute(Query.of(query))).getAlertsPolicyCreate().get();
+    }
+
+    @Override
+    public AlertsPolicy delete(int policyId) {
+        AlertsPolicy policy = throwOnError(doGetById(policyId)).getAlertsPolicy().get();
+
+        String query = query()
+                .object("mutation",
+                        object(mutation -> mutation.object(
+                                "alertsPolicyDelete",
+                                params(
+                                        "accountId", accountId,
+                                        "id", "" + policyId),
+                                object(alertsPolicyDelete -> alertsPolicyDelete.field("id")))))
+                .build();
+
+        throwOnError(execute(Query.of(query)));
+        return policy;
+    }
+
+    @Override
+    public AlertsPolicyChannels updateChannels(AlertsPolicyChannels channels) {
+        checkArgument(nonNull(channels), "channels must not be null");
+        checkArgument(nonNull(channels.getPolicyId()), "policy id must not be null");
+
+        String query = query()
+                .object("mutation",
+                        object(mutation -> mutation.object(
+                                "alertsNotificationChannelsAddToPolicy",
+                                params(
+                                        "accountId", accountId,
+                                        "policyId", channels.getPolicyId(),
+                                        "notificationChannelIds", Optional.ofNullable(channels.getChannelIds()).orElseGet(ArrayList::new)),
+                                object(alertsNotificationChannelsAddToPolicy -> alertsNotificationChannelsAddToPolicy
+                                        .object("notificationChannels", object(notificationChannels -> notificationChannels
+                                                .field("id")))
+                                        .object("errors", object(errors -> errors
+                                                .field("description")
+                                                .field("errorType")
+                                                .field("notificationChannelId")))))))
+                .build();
+
+        List<Integer> notificationChannelIds = throwOnError(execute(Query.of(query)), Result::getAlertsNotificationChannelsAddToPolicy)
+                .orElseGet(ArrayList::new);
+        return AlertsPolicyChannels.builder().policyId(channels.getPolicyId()).channelIds(notificationChannelIds).build();
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/ModelTranslator.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/ModelTranslator.java
@@ -1,0 +1,319 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ocadotechnology.newrelic.apiclient.model.channels.AlertsChannel;
+import com.ocadotechnology.newrelic.apiclient.model.channels.AlertsChannelConfiguration;
+import com.ocadotechnology.newrelic.apiclient.model.channels.AlertsChannelLinks;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Expiration;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Signal;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Terms;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.Nrql;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.*;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.commons.text.StringEscapeUtils;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.*;
+import java.util.function.Consumer;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.ocadotechnology.newrelic.graphql.apiclient.internal.util.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+@RequiredArgsConstructor
+public class ModelTranslator {
+    private static final ObjectMapper DEFAULT_OBJECT_MAPPER = new ObjectMapper()
+            .disable(FAIL_ON_UNKNOWN_PROPERTIES);
+
+    private final ObjectMapper objectMapper;
+
+    public ModelTranslator() {
+        this.objectMapper = DEFAULT_OBJECT_MAPPER;
+    }
+
+    public AlertsChannel toModel(NotificationChannel notificationChannel) {
+        return Optional.ofNullable(notificationChannel)
+                .map(channel -> AlertsChannel.builder()
+                        .id(Optional.ofNullable(channel.getId()).map(Integer::parseInt).orElse(null))
+                        .name(channel.getName())
+                        .type(Optional.ofNullable(channel.getType()).map(String::toLowerCase).orElse(null))
+                        .links(new AlertsChannelLinks(Optional.ofNullable(channel.getAssociatedPolicies())
+                                .map(AssociatedPolicies::getPolicies)
+                                .orElse(Collections.emptyList())
+                                .stream().map(Identifiable::getId)
+                                .collect(toList())))
+                        .configuration(toModel(channel.getConfig()))
+                        .build())
+                .orElse(null);
+    }
+
+    public AlertsNrqlCondition toModel(NrqlCondition dto) {
+        return AlertsNrqlCondition.builder()
+                .id(Optional.ofNullable(dto.getId()).map(Integer::parseInt).orElse(null))
+                .name(dto.getName())
+                .enabled(dto.getEnabled())
+                .runbookUrl(dto.getRunbookUrl())
+                .nrql(Optional.ofNullable(dto.getNrql())
+                        .map(nrql -> new Nrql(nrql.getQuery()))
+                        .orElse(null))
+                .expiration(Optional.ofNullable(dto.getExpiration())
+                        .map(expiration -> Expiration.builder()
+                                .closeViolationsOnExpiration(expiration.isCloseViolationsOnExpiration())
+                                .expirationDuration(expiration.getExpirationDuration())
+                                .openViolationOnExpiration(expiration.isOpenViolationOnExpiration())
+                                .build())
+                        .orElse(null))
+                .signal(Optional.ofNullable(dto.getSignal())
+                        .map(signal -> Signal.builder()
+                                .aggregationDelay(signal.getAggregationDelay())
+                                .aggregationMethod(Optional.ofNullable(signal.getAggregationMethod()).map(String::toUpperCase).orElse(null))
+                                .aggregationTimer(signal.getAggregationTimer())
+                                .aggregationWindow(signal.getAggregationWindow())
+                                .fillOption(Optional.ofNullable(signal.getFillOption()).map(String::toLowerCase).orElse(null))
+                                .fillValue(signal.getFillValue())
+                                .build())
+                        .orElse(null))
+                .terms(Optional.ofNullable(dto.getTerms())
+                        .map(terms -> terms.stream()
+                                .map(term -> Terms.builder()
+                                        .operator(Optional.ofNullable(term.getOperator()).map(String::toLowerCase).orElse(null))
+                                        .priority(Optional.ofNullable(term.getPriority()).map(String::toLowerCase).orElse(null))
+                                        .threshold(term.getThreshold())
+                                        .duration(Optional.ofNullable(term.getThresholdDuration())
+                                                .map(Long::parseLong)
+                                                .map(durationSeconds -> "" + (long) (durationSeconds / 60))
+                                                .orElse(null))
+                                        .timeFunction(Optional.ofNullable(term.getThresholdOccurrences())
+                                                .map(this::thresholdOccurrencesToTimeFunctionTo)
+                                                .map(String::toLowerCase)
+                                                .orElse(null))
+                                        .build())
+                                .collect(toList()))
+                        .orElse(null))
+                .valueFunction(Optional.ofNullable(dto.getValueFunction()).map(String::toLowerCase).orElse(null))
+                .build();
+    }
+
+    private AlertsChannelConfiguration toModel(NotificationChannelConfig dto) {
+        return Optional.ofNullable(dto)
+                .filter(config -> !config.isEmpty())
+                .map(config -> AlertsChannelConfiguration.builder()
+                        .recipients(Optional.ofNullable(config.getEmails()).orElse(emptyList())
+                                .stream().reduce(null, (acc, email) -> (isNull(acc) ? "" : acc + ",") + email))
+                        .includeJsonAttachment(config.getIncludeJson())
+                        .userId(Optional.ofNullable(config.getUserId())
+                                .map(Integer::parseInt).orElse(null))
+                        .channel(config.getTeamChannel())
+                        .baseUrl(config.getBaseUrl())
+                        .headers(Optional.ofNullable(config.getCustomHttpHeaders())
+                                .map(httpHeaders -> httpHeaders.stream().collect(toMap(HttpHeader::getName, HttpHeader::getValue)))
+                                .filter(httpHeaders -> !httpHeaders.isEmpty())
+                                .orElse(null))
+                        .authUsername(Optional.ofNullable(config.getBasicAuth()).map(NotificationChannelConfig.BasicAuth::getUsername).orElse(null))
+                        .payloadType(payloadTypeToModel(config.getCustomPayloadType()))
+                        .payload(payloadToModel(config.getCustomPayloadType(), config.getCustomPayloadBody()))
+                        .build()
+                ).orElse(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> toChannelConfig(String type, String name, AlertsChannelConfiguration configuration) {
+        checkArgument(nonNull(type), "channel type cannot be null");
+        checkArgument(nonNull(name), "channel name cannot be null");
+        checkArgument(nonNull(configuration), "configuration name cannot be null");
+
+        Map<String, Object> config = map();
+        config.put("name", name);
+        String wrapperName = type;
+        switch (type) {
+            case "email":
+                config.put("emails", Optional.ofNullable(configuration.getRecipients())
+                        .map(recipients -> Arrays.stream(recipients.split(",")).map(String::trim).collect(toList())).orElse(null));
+                config.put("includeJson", Optional.ofNullable(configuration.getIncludeJsonAttachment()).orElse(false));
+                break;
+            case "pagerduty":
+                config.put("apiKey", configuration.getServiceKey());
+                wrapperName = "pagerDuty";
+                break;
+            case "slack":
+                config.put("teamChannel", configuration.getChannel());
+                config.put("url", configuration.getUrl());
+                break;
+            case "webhook":
+                AlertsWebhookCustomPayloadType payloadType = Optional.ofNullable(configuration.getPayloadType())
+                        .map(AlertsWebhookCustomPayloadType::byType).orElse(null);
+
+                config.put("baseUrl", configuration.getBaseUrl());
+                config.put("basicAuth", Optional.ofNullable(configuration.getAuthUsername())
+                        .map(__ -> {
+                            Map<String, Object> basicAuth = map();
+                            basicAuth.put("username", configuration.getAuthUsername());
+                            basicAuth.put("password", configuration.getAuthPassword());
+                            return basicAuth;
+                        }).orElse(null));
+                config.put("customPayloadType", Optional.ofNullable(payloadType)
+                        .map(t -> new JavaLikeEnum(t.toString())).orElse(null));
+                config.put("customHttpHeaders", Optional.ofNullable(configuration.getHeaders())
+                        .map(headers -> headers.entrySet().stream().map(header -> {
+                            Map<String, String> headerObject = map();
+                            headerObject.put("name", header.getKey());
+                            headerObject.put("value", header.getValue());
+                            return headerObject;
+                        }).collect(toList())).orElse(null));
+                config.put("customPayloadBody", Optional.ofNullable(configuration.getPayload())
+                        .flatMap(__ -> Optional.ofNullable(payloadType))
+                        .map(pt -> {
+                            switch (pt) {
+                                case JSON:
+                                    return writeJson(configuration.getPayload());
+                                case FORM:
+                                    return configuration.getPayload() instanceof String
+                                            ? configuration.getPayload()
+                                            : writeProperties((Map<String, Object>) configuration.getPayload());
+                            }
+                            return null;
+                        }).orElse(null)
+                );
+                break;
+            default:
+                throw new IllegalArgumentException(format("Unsupported channel type: '%s'", type));
+        }
+
+        Map<String, Object> wrapper = new HashMap<>();
+        wrapper.put(wrapperName, config);
+        return wrapper;
+    }
+
+    public Map<String, Object> toNrqlCondition(AlertsNrqlCondition condition) {
+        Map<String, Object> cond = map();
+        cond.put("enabled", condition.getEnabled());
+        cond.put("name", condition.getName());
+        onPresent(condition.getRunbookUrl(), runbookUrl -> cond.put("runbookUrl", runbookUrl));
+        Map<String, Object> nrql = map();
+        nrql.put("query", Optional.ofNullable(condition.getNrql()).map(Nrql::getQuery).orElse(null));
+        cond.put("nrql", nrql);
+        onPresent(condition.getExpiration(), expiration -> {
+            Map<String, Object> result = map();
+            result.put("closeViolationsOnExpiration", expiration.isCloseViolationsOnExpiration());
+            result.put("openViolationOnExpiration", expiration.isOpenViolationOnExpiration());
+            onPresent(expiration.getExpirationDuration(),
+                    expirationDuration -> result.put("expirationDuration", toLong(expiration.getExpirationDuration())));
+            cond.put("expiration", result);
+        });
+        onPresent(condition.getSignal(), signal -> {
+            Map<String, Object> result = map();
+            onPresent(signal.getAggregationDelay(), aggregationDelay -> result.put("aggregationDelay", toLong(aggregationDelay)));
+            onPresent(signal.getAggregationMethod(), aggregationMethod -> result.put("aggregationMethod", toEnum(aggregationMethod)));
+            onPresent(signal.getAggregationTimer(), aggregationTimer -> result.put("aggregationTimer", toLong(aggregationTimer)));
+            onPresent(signal.getAggregationWindow(), aggregationWindow -> result.put("aggregationWindow", toLong(aggregationWindow)));
+            onPresent(signal.getFillOption(), fillOption -> result.put("fillOption", toEnum(fillOption)));
+            onPresent(signal.getFillValue(), fillValue -> result.put("fillValue", fillValue));
+            cond.put("signal", result);
+        });
+        cond.put("terms", Optional.ofNullable(condition.getTerms()).orElseGet(ArrayList::new).stream()
+                .map(term -> {
+                    LinkedHashMap<String, Object> result = map();
+                    onPresent(term.getOperator(), operator -> result.put("operator", toEnum(operator)));
+                    onPresent(term.getPriority(), priority -> result.put("priority", toEnum(priority)));
+                    onPresent(term.getThreshold(), threshold -> result.put("threshold", toFloat(threshold)));
+                    onPresent(term.getDuration(), duration -> result.put("thresholdDuration", toLong(duration) * 60));
+                    onPresent(term.getTimeFunction(), timeFunction -> result.put("thresholdOccurrences", toEnum(timeFunctionToThresholdOccurrences(timeFunction))));
+                    return result;
+                })
+                .collect(toList()));
+        onPresent(condition.getValueFunction(), valueFunction -> cond.put("valueFunction", toEnum(valueFunction)));
+        return cond;
+    }
+
+    private String timeFunctionToThresholdOccurrences(String input) {
+        return input.equalsIgnoreCase("any") ? "at_least_once" : input;
+    }
+
+    private String thresholdOccurrencesToTimeFunctionTo(String input) {
+        return input.equalsIgnoreCase("at_least_once") ? "any" : input;
+    }
+
+    private static <T1, T2> LinkedHashMap<T1, T2> map() {
+        return new LinkedHashMap<>();
+    }
+
+    private JavaLikeEnum toEnum(String fillOption) {
+        return new JavaLikeEnum(fillOption.toUpperCase());
+    }
+
+    private long toLong(String value) {
+        return Long.parseLong(value);
+    }
+
+    private float toFloat(String value) {
+        return Float.parseFloat(value);
+    }
+
+    private <T> void onPresent(T object, Consumer<T> consumer) {
+        if (Objects.nonNull(object)) {
+            consumer.accept(object);
+        }
+    }
+
+    private String payloadTypeToModel(String customPayloadType) {
+        return Optional.ofNullable(customPayloadType)
+                .map(AlertsWebhookCustomPayloadType::valueOf)
+                .map(AlertsWebhookCustomPayloadType::getType)
+                .orElse(null);
+    }
+
+    private Map<String, Object> payloadToModel(String customPayloadType, String customPayloadBody) {
+        return Optional.ofNullable(customPayloadBody)
+                .map(__ -> customPayloadType)
+                .map(AlertsWebhookCustomPayloadType::valueOf)
+                .map(type -> {
+                    switch (type) {
+                        case JSON:
+                            return readJson(StringEscapeUtils.unescapeJson(customPayloadBody));
+                        case FORM:
+                            return readProperties(customPayloadBody);
+                        default:
+                            return null;
+                    }
+                })
+                .orElse(null);
+    }
+
+    @SneakyThrows
+    private String writeJson(Object value) {
+        return objectMapper.writeValueAsString(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @SneakyThrows
+    private Map<String, Object> readJson(String value) {
+        return objectMapper.readValue(value, Map.class);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SneakyThrows
+    private Map<String, Object> readProperties(String value) {
+        Properties properties = new Properties();
+        properties.load(new StringReader(value));
+        return (Map<String, Object>) (Map) properties;
+    }
+
+    @SneakyThrows
+    public static String writeProperties(Map<String, Object> value) {
+        Properties properties = new Properties();
+        properties.putAll(value);
+        StringWriter writer = new StringWriter();
+        properties.store(writer, null);
+        String output = writer.toString();
+        String sep = System.getProperty("line.separator");
+        return output.substring(output.indexOf(sep) + sep.length()).trim().replaceAll(sep, "\n");
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/QueryExecutor.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/QueryExecutor.java
@@ -1,0 +1,8 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Result;
+
+public interface QueryExecutor {
+    Result execute(Query query);
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/AlertsWebhookCustomPayloadType.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/AlertsWebhookCustomPayloadType.java
@@ -1,0 +1,24 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+
+import static java.lang.String.format;
+
+public enum AlertsWebhookCustomPayloadType {
+    FORM("application/x-www-form-urlencoded"),
+    JSON("application/json");
+
+    @Getter
+    private final String type;
+
+    AlertsWebhookCustomPayloadType(String type) {
+        this.type = type;
+    }
+
+    public static AlertsWebhookCustomPayloadType byType(String value) {
+        return Arrays.stream(values()).filter(type -> type.getType().equalsIgnoreCase(value))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException(format("unknown payload type: '%s'", value)));
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/AssociatedPolicies.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/AssociatedPolicies.java
@@ -1,0 +1,12 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Value;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+public class AssociatedPolicies {
+    List<Identifiable> policies;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Error.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Error.java
@@ -1,0 +1,18 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Value;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+public class Error {
+    Extensions extensions;
+    String message;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    public static class Extensions {
+        String code;
+        String errorClass;
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/HttpHeader.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/HttpHeader.java
@@ -1,0 +1,9 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import lombok.Value;
+
+@Value
+public class HttpHeader {
+    String name;
+    String value;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Identifiable.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Identifiable.java
@@ -1,0 +1,10 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Value;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+public class Identifiable {
+    Integer id;
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/JavaLikeEnum.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/JavaLikeEnum.java
@@ -1,0 +1,42 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import lombok.Value;
+
+import java.io.IOException;
+
+import static com.ocadotechnology.newrelic.graphql.apiclient.internal.util.Preconditions.checkArgument;
+
+@JsonSerialize(using = JavaLikeEnumSerializer.class)
+@Value
+public class JavaLikeEnum {
+    String value;
+
+    public JavaLikeEnum(String value) {
+        checkArgument(value != null, "Value cannot be null");
+
+        String normalizedValue = value.replaceAll("[^A-Za-z0-9_]", "");
+        checkArgument(!normalizedValue.isEmpty(), "Value cannot be empty");
+
+        this.value = normalizedValue;
+    }
+}
+
+class JavaLikeEnumSerializer extends StdSerializer<JavaLikeEnum> {
+
+    public JavaLikeEnumSerializer() {
+        this(JavaLikeEnum.class);
+    }
+
+    protected JavaLikeEnumSerializer(Class<JavaLikeEnum> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(JavaLikeEnum value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        jgen.writeRawValue(value.getValue());
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NotificationChannel.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NotificationChannel.java
@@ -1,0 +1,15 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Value;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+public class NotificationChannel {
+    String id;
+    String name;
+    String type;
+    AssociatedPolicies associatedPolicies;
+    NotificationChannelConfig config;
+
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NotificationChannelConfig.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NotificationChannelConfig.java
@@ -1,0 +1,43 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+
+import static java.util.Objects.isNull;
+
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+public class NotificationChannelConfig {
+    List<String> emails;
+    Boolean includeJson;
+    String userId;
+    String teamChannel;
+    String baseUrl;
+    String customPayloadType;
+    List<HttpHeader> customHttpHeaders;
+    String customPayloadBody;
+    BasicAuth basicAuth;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    public static class BasicAuth {
+        String username;
+        String password;
+    }
+
+    public boolean isEmpty(){
+        return isNull(emails) &&
+                isNull(includeJson) &&
+                isNull(userId) &&
+                isNull(teamChannel) &&
+                isNull(baseUrl) &&
+                isNull(customPayloadType) &&
+                isNull(customHttpHeaders) &&
+                isNull(customPayloadBody) &&
+                isNull(basicAuth);
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NotificationChannels.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NotificationChannels.java
@@ -1,0 +1,18 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Value;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+public class NotificationChannels implements Page<List<NotificationChannel>> {
+    List<NotificationChannel> channels;
+    String nextCursor;
+
+    @Override
+    public List<NotificationChannel> getContent() {
+        return getChannels();
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NrqlCondition.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NrqlCondition.java
@@ -1,0 +1,56 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Value;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+public class NrqlCondition {
+    Boolean enabled;
+    String id;
+    String name;
+    String type;
+    String runbookUrl;
+    Nrql nrql;
+    Expiration expiration;
+    Signal signal;
+    List<Term> terms;
+    String valueFunction;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    public static class Nrql {
+        String query;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    public static class Expiration {
+        String expirationDuration;
+        boolean openViolationOnExpiration;
+        boolean closeViolationsOnExpiration;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    public static class Signal {
+        String aggregationMethod;
+        String aggregationDelay;
+        String aggregationTimer;
+        String aggregationWindow;
+        String fillOption;
+        String fillValue;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    public static class Term {
+        String operator;
+        String priority;
+        String threshold;
+        String thresholdDuration;
+        String thresholdOccurrences;
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NrqlConditionsSearch.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/NrqlConditionsSearch.java
@@ -1,0 +1,18 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Value;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+public class NrqlConditionsSearch implements Page<List<NrqlCondition>> {
+    List<NrqlCondition> nrqlConditions;
+    String nextCursor;
+
+    @Override
+    public List<NrqlCondition> getContent() {
+        return getNrqlConditions();
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Page.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Page.java
@@ -1,0 +1,9 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import java.util.List;
+
+public interface Page<T extends List> {
+    String getNextCursor();
+
+    T getContent();
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/PageIterator.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/PageIterator.java
@@ -1,0 +1,33 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+@RequiredArgsConstructor
+public class PageIterator<C, W extends Page<List<C>>> implements Iterator<List<C>> {
+    private W current;
+
+    private final Function<String, Optional<W>> fetch;
+
+    @Override
+    public boolean hasNext() {
+        return isNull(current) || nonNull(current.getNextCursor());
+    }
+
+    @Override
+    public List<C> next() {
+        if (hasNext()) {
+            current = fetch.apply(Optional.ofNullable(current).map(Page::getNextCursor).orElse("")).get();
+            return Optional.ofNullable(current.getContent()).orElseGet(ArrayList::new);
+        }
+        throw new IllegalStateException("Cannot get next");
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Query.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Query.java
@@ -1,0 +1,25 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+import static com.ocadotechnology.newrelic.graphql.apiclient.internal.util.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static lombok.AccessLevel.PACKAGE;
+
+@Value
+@RequiredArgsConstructor(access = PACKAGE)
+public class Query {
+
+    public String query;
+
+    public static Query of(String query) {
+        checkArgument(query != null, "Query must not be null");
+        return new Query(query);
+    }
+
+    public static Query wrapped(String query) {
+        checkArgument(query != null, "Query must not be null");
+        return new Query(format("{    %s    }", query));
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Result.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/Result.java
@@ -1,0 +1,169 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ocadotechnology.newrelic.apiclient.model.policies.AlertsPolicy;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.mutation.EmptyMutationResult;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.mutation.MutationResult;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.mutation.NotificationChannelResult;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.mutation.NotificationChannelsResult;
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+import lombok.Value;
+
+import java.util.*;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ToString
+@AllArgsConstructor
+public class Result {
+    private final Data data;
+
+    private final List<Error> errors;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    static class Data {
+        Actor actor;
+        AlertsPolicyCreate alertsPolicyCreate;
+        EmptyMutationResult alertsNotificationChannelDelete;
+        NotificationChannelsResult alertsNotificationChannelsAddToPolicy;
+        NotificationChannelsResult alertsNotificationChannelsRemoveFromPolicy;
+
+        NotificationChannelResult alertsNotificationChannelCreate;
+
+        NrqlCondition alertsNrqlConditionStaticCreate;
+        NrqlCondition alertsNrqlConditionStaticUpdate;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    static class Actor {
+        EntitySearch entitySearch;
+        Account account;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    static class AlertsPolicyCreate {
+        String id;
+        String name;
+        String incidentPreference;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    static class Account {
+        Alerts alerts;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    static class Alerts {
+        AlertsPolicy policy;
+        NotificationChannel notificationChannel;
+        NotificationChannels notificationChannels;
+        PoliciesSearch policiesSearch;
+        NrqlConditionsSearch nrqlConditionsSearch;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    static class PoliciesSearch {
+        List<AlertsPolicy> policies;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    static class EntitySearch {
+        Results results;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Value
+    static class Results {
+        List<Map<Object, Object>> entities;
+    }
+
+    public boolean hasErrors() {
+        return Objects.nonNull(errors);
+    }
+
+    public boolean notFound() {
+        return Optional.ofNullable(errors)
+                .orElseGet(ArrayList::new).stream()
+                .anyMatch(error -> "Not Found".equalsIgnoreCase(error.getMessage()));
+    }
+
+    public List<Error> getErrors() {
+        return Optional.ofNullable(errors).orElseGet(ArrayList::new);
+    }
+
+    public List<AlertsPolicy> getPolicies() {
+        return getAlerts()
+                .map(alerts -> alerts.policiesSearch)
+                .map(policiesSearch -> policiesSearch.policies).orElseGet(ArrayList::new);
+    }
+
+    public Optional<AlertsPolicy> getAlertsPolicyCreate() {
+        return getData()
+                .map(data -> data.alertsPolicyCreate)
+                .map(alertsPolicyCreate -> AlertsPolicy.builder()
+                        .id(Optional.ofNullable(alertsPolicyCreate.id).map(Integer::parseInt).orElse(null))
+                        .name(alertsPolicyCreate.name)
+                        .incidentPreference(alertsPolicyCreate.incidentPreference)
+                        .build());
+    }
+
+    public Optional<MutationResult<List<Integer>>> getAlertsNotificationChannelsAddToPolicy() {
+        return getData().map(data -> data.alertsNotificationChannelsAddToPolicy);
+    }
+
+    public Optional<MutationResult<List<Integer>>> getAlertsNotificationChannelsRemoveFromPolicy() {
+        return getData().map(data -> data.alertsNotificationChannelsRemoveFromPolicy);
+    }
+
+    public Optional<NotificationChannelResult> getAlertsNotificationChannelCreate() {
+        return getData().map(data -> data.alertsNotificationChannelCreate);
+    }
+
+    public Optional<MutationResult<Void>> getAlertsNotificationChannelDelete() {
+        return getData().map(data -> data.alertsNotificationChannelDelete);
+    }
+
+    public Optional<AlertsPolicy> getAlertsPolicy() {
+        return getAlerts().map(alerts -> alerts.policy);
+    }
+
+    public Optional<NotificationChannel> getNotificationChannel() {
+        return getAlerts().map(alerts -> alerts.notificationChannel);
+    }
+
+    public Optional<NotificationChannels> getNotificationChannels() {
+        return getAlerts().map(alerts -> alerts.notificationChannels);
+    }
+
+    public Optional<NrqlConditionsSearch> getNrqlConditionsSearch() {
+        return getAlerts().map(alerts -> alerts.nrqlConditionsSearch);
+    }
+
+    public Optional<NrqlCondition> getAlertsNrqlConditionStaticCreate() {
+        return getData().map(data -> data.alertsNrqlConditionStaticCreate);
+    }
+
+    public Optional<NrqlCondition> getAlertsNrqlConditionStaticUpdate() {
+        return getData().map(data -> data.alertsNrqlConditionStaticUpdate);
+    }
+
+    private Optional<Data> getData() {
+        return Optional.ofNullable(data);
+    }
+
+    private Optional<Alerts> getAlerts() {
+        return getData()
+                .map(data -> data.actor)
+                .map(actor -> actor.account)
+                .map(account -> account.alerts);
+    }
+
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/mutation/EmptyMutationResult.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/mutation/EmptyMutationResult.java
@@ -1,0 +1,29 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.mutation;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static lombok.AccessLevel.NONE;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+@Getter(NONE)
+public class EmptyMutationResult implements MutationResult<Void> {
+    Map<String, Object> error;
+
+    @Override
+    public Void get() {
+        return null;
+    }
+
+    @Override
+    public List<Map<String, Object>> getErrors() {
+        return Optional.ofNullable(error).map(e -> singletonList(error)).orElse(null);
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/mutation/MutationResult.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/mutation/MutationResult.java
@@ -1,0 +1,16 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.mutation;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.nonNull;
+
+public interface MutationResult<T> {
+    T get();
+
+    List<Map<String, Object>> getErrors();
+
+    default boolean hasErrors() {
+        return nonNull(getErrors()) && !getErrors().isEmpty();
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/mutation/NotificationChannelResult.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/mutation/NotificationChannelResult.java
@@ -1,0 +1,31 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.mutation;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.NotificationChannel;
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static lombok.AccessLevel.NONE;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+@Getter(NONE)
+public class NotificationChannelResult implements MutationResult<NotificationChannel> {
+    NotificationChannel notificationChannel;
+    Map<String, Object> error;
+
+    @Override
+    public NotificationChannel get() {
+        return notificationChannel;
+    }
+
+    @Override
+    public List<Map<String, Object>> getErrors() {
+        return Optional.ofNullable(error).map(e -> singletonList(error)).orElse(null);
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/mutation/NotificationChannelsResult.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/mutation/NotificationChannelsResult.java
@@ -1,0 +1,33 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.mutation;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Identifiable;
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
+import static lombok.AccessLevel.NONE;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Value
+@Getter(NONE)
+public class NotificationChannelsResult implements MutationResult<List<Integer>> {
+    List<Identifiable> notificationChannels;
+    List<Map<String, Object>> errors;
+
+    @Override
+    public List<Integer> get() {
+        return Optional.ofNullable(notificationChannels).orElseGet(ArrayList::new).stream()
+                .map(Identifiable::getId).collect(toList());
+    }
+
+    @Override
+    public List<Map<String, Object>> getErrors() {
+        return errors;
+    }
+}

--- a/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/util/Preconditions.java
+++ b/newrelic-api-client/src/main/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/util/Preconditions.java
@@ -1,0 +1,16 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.util;
+
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+
+@NoArgsConstructor(access = PRIVATE)
+public final class Preconditions {
+
+    public static void checkArgument(boolean expression, Object errorMessage) {
+        if (!expression) {
+            throw new IllegalArgumentException(String.valueOf(errorMessage));
+        }
+    }
+}

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/NewRelicApiIntegrationTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/apiclient/NewRelicApiIntegrationTest.java
@@ -1,11 +1,13 @@
 package com.ocadotechnology.newrelic.apiclient;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static org.apache.http.HttpStatus.SC_OK;
-import static org.assertj.core.api.Assertions.assertThat;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.ocadotechnology.newrelic.apiclient.model.applications.Application;
+import com.ocadotechnology.newrelic.apiclient.model.channels.AlertsChannel;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -16,15 +18,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpHeaders;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import com.ocadotechnology.newrelic.apiclient.model.applications.Application;
-import com.ocadotechnology.newrelic.apiclient.model.channels.AlertsChannel;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class NewRelicApiIntegrationTest {
     @ClassRule
@@ -41,7 +37,7 @@ public class NewRelicApiIntegrationTest {
     @Before
     public void setUp() throws IOException {
         WIRE_MOCK.resetMappings();
-        testee = new NewRelicApi("http://localhost:6766", "http://localhost:6766", "secret");
+        testee = new NewRelicRestApi("http://localhost:6766", "http://localhost:6766", "secret");
         applications = IOUtils.toString(NewRelicApiIntegrationTest.class.getResource("/applications.json"), UTF_8);
         channels1 = IOUtils.toString(NewRelicApiIntegrationTest.class.getResource("/channels1.json"), UTF_8);
         channels2 = IOUtils.toString(NewRelicApiIntegrationTest.class.getResource("/channels2.json"), UTF_8);

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsChannelsApiTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsChannelsApiTest.java
@@ -1,0 +1,503 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.ocadotechnology.newrelic.apiclient.model.channels.AlertsChannel;
+import com.ocadotechnology.newrelic.apiclient.model.channels.AlertsChannelConfiguration;
+import com.ocadotechnology.newrelic.apiclient.model.channels.AlertsChannelLinks;
+import com.ocadotechnology.newrelic.graphql.apiclient.GraphqlApiError;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.testutil.QueryExecutorMock;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.ocadotechnology.newrelic.graphql.apiclient.internal.testutil.TestResources.fromJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+public class GraphqlAlertsChannelsApiTest {
+    private static final int ACCOUNT_ID = 12345678;
+
+    private final QueryExecutorMock executor = new QueryExecutorMock();
+    private GraphqlAlertsChannelsApi testee;
+
+    @Before
+    public void setUp() {
+        testee = new GraphqlAlertsChannelsApi(executor, ACCOUNT_ID);
+    }
+
+    @Test
+    public void getById_email() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                result("/AlertChannels_getById_email_response.json"));
+
+        // when
+        Optional<AlertsChannel> channelOptional = testee.getById(1111111);
+
+        // then
+        assertThat(channelOptional).isNotEmpty();
+        assertThat(channelOptional.get()).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Email Channel")
+                .type("email")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .recipients("email@domain.com,other@domain.com")
+                        .includeJsonAttachment(true)
+                        .build())
+                .links(new AlertsChannelLinks(ImmutableList.of(1234567)))
+                .build());
+    }
+
+    @Test
+    public void getById_user() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                result("/AlertChannels_getById_user_response.json"));
+
+        // when
+        Optional<AlertsChannel> channelOptional = testee.getById(1111111);
+
+        // then
+        assertThat(channelOptional).isNotEmpty();
+        assertThat(channelOptional.get()).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test User Channel")
+                .type("user")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .userId(2111111111)
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void getById_slack() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                result("/AlertChannels_getById_slack_response.json"));
+
+        // when
+        Optional<AlertsChannel> channelOptional = testee.getById(1111111);
+
+        // then
+        assertThat(channelOptional).isNotEmpty();
+        assertThat(channelOptional.get()).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Slack Channel")
+                .type("slack")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .channel("test-slack-channel")
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void getById_pagerDuty() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                result("/AlertChannels_getById_pagerduty_response.json"));
+
+        // when
+        Optional<AlertsChannel> channelOptional = testee.getById(1111111);
+
+        // then
+        assertThat(channelOptional).isNotEmpty();
+        assertThat(channelOptional.get()).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Pagerduty Channel")
+                .type("pagerduty")
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void getById_json_webhook() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                result("/AlertChannels_getById_webhook_json_response.json"));
+
+        // when
+        Optional<AlertsChannel> channelOptional = testee.getById(1111111);
+
+        // then
+        assertThat(channelOptional).isNotEmpty();
+        assertThat(channelOptional.get()).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Webhook Channel")
+                .type("webhook")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .baseUrl("https://address.domain.com")
+                        .headers(ImmutableMap.of(
+                                "Custom-Header", "CUSTOM-VALUE",
+                                "Custom-Header-2", "CUSTOM-VALUE-2"))
+                        .payloadType("application/json")
+                        .payload(ImmutableMap.of("field", "value"))
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void getById_form_webhook() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                result("/AlertChannels_getById_webhook_form_response.json"));
+
+        // when
+        Optional<AlertsChannel> channelOptional = testee.getById(1111111);
+
+        // then
+        assertThat(channelOptional).isNotEmpty();
+        assertThat(channelOptional.get()).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Webhook Channel")
+                .type("webhook")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .baseUrl("https://address.domain.com")
+                        .authUsername("test")
+                        .payloadType("application/x-www-form-urlencoded")
+                        .payload(ImmutableMap.of(
+                                "current_state", "acknowledged",
+                                "account_name", "$ACCOUNT_NAME"))
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void getById_shouldReturnEmpty_whenChannelNotFound() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                result("/AlertChannels_getById_notFound.json"));
+
+        // when
+        Optional<AlertsChannel> channelOptional = testee.getById(1111111);
+
+        // then
+        assertThat(channelOptional).isEmpty();
+    }
+
+    @Test
+    public void list() {
+        // given
+        executor
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertChannels_list_request_part1.txt")),
+                        result("/AlertChannels_list_response_part1.json"))
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertChannels_list_request_part2.txt")),
+                        result("/AlertChannels_list_response_part2.json"));
+
+        // when
+        List<AlertsChannel> channels = testee.list();
+
+        // then
+        assertThat(channels).hasSize(3);
+        assertThat(channels).extracting(AlertsChannel::getId, AlertsChannel::getType).containsExactly(
+                tuple(1111111, "email"),
+                tuple(2222222, "webhook"),
+                tuple(3333333, "slack"));
+    }
+
+    @Test
+    public void list_shouldThrow_onError() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertChannels_list_request_part1.txt")),
+                result("/AlertChannels_list_error.json"));
+
+        // then
+        assertThatThrownBy(() -> testee.list()).isInstanceOf(GraphqlApiError.class);
+    }
+
+    @Test
+    public void deleteFromPolicy() {
+        // given
+        executor
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                        result("/AlertChannels_getById_email_response.json"))
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_deleteFromPolicy_request.txt")),
+                        result("/AlertChannels_deleteFromPolicy_response.json"));
+
+        // when
+        AlertsChannel channel = testee.deleteFromPolicy(7654321, 1111111);
+
+        // then
+        assertThat(channel).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Email Channel")
+                .type("email")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .recipients("email@domain.com,other@domain.com")
+                        .includeJsonAttachment(true)
+                        .build())
+                .links(new AlertsChannelLinks(ImmutableList.of(1234567)))
+                .build());
+    }
+
+    @Test
+    public void deleteFromPolicy_shouldThrow_onError() {
+        // given
+        executor
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                        result("/AlertChannels_getById_email_response.json"))
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_deleteFromPolicy_request.txt")),
+                        result("/AlertChannels_deleteFromPolicy_error.json"));
+
+        // then
+        assertThatThrownBy(() -> testee.deleteFromPolicy(7654321, 1111111))
+                .isInstanceOf(GraphqlApiError.class);
+    }
+
+    @Test
+    public void create_email() {
+        // given
+        executor
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_create_email_request.txt")),
+                        result("/AlertChannels_create_email_response.json"));
+
+        // when
+        AlertsChannel channel = testee.create(AlertsChannel.builder()
+                .name("Test Email Channel")
+                .type("email")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .recipients("email@domain.com,other@domain.com")
+                        .build())
+                .build());
+
+        // then
+        assertThat(channel).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Email Channel")
+                .type("email")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .recipients("email@domain.com,other@domain.com")
+                        .includeJsonAttachment(false)
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void create_pagerduty() {
+        // given
+        executor
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_create_pagerduty_request.txt")),
+                        result("/AlertChannels_create_pagerduty_response.json"));
+
+        // when
+        AlertsChannel channel = testee.create(AlertsChannel.builder()
+                .name("Test PagerDuty Channel")
+                .type("pagerduty")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .serviceKey("abcdefghijklmnopqRSTUVWXYZ")
+                        .build())
+                .build());
+
+        // then
+        assertThat(channel).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test PagerDuty Channel")
+                .type("pagerduty")
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void create_slack() {
+        // given
+        executor
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_create_slack_request.txt")),
+                        result("/AlertChannels_create_slack_response.json"));
+
+        // when
+        AlertsChannel channel = testee.create(AlertsChannel.builder()
+                .name("Test Slack Channel")
+                .type("slack")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .channel("the channel")
+                        .url("https://domain.com/slack")
+                        .build())
+                .build());
+
+        // then
+        assertThat(channel).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Slack Channel")
+                .type("slack")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .channel("the channel")
+                        .url("***************om/slack")
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void create_json_webhook() {
+        // given
+        executor
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_create_webhook_json_request.txt")),
+                        result("/AlertChannels_create_webhook_json_response.json"));
+
+        // when
+        AlertsChannel channel = testee.create(AlertsChannel.builder()
+                .name("Test Webhook Channel")
+                .type("webhook")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .baseUrl("https://address.domain.com")
+                        .headers(ImmutableMap.of(
+                                "Custom-Header", "CUSTOM-VALUE",
+                                "Custom-Header-2", "CUSTOM-VALUE-2"))
+                        .payloadType("application/json")
+                        .payload(ImmutableMap.of("field", "value"))
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+
+        // then
+        assertThat(channel).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Webhook Channel")
+                .type("webhook")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .baseUrl("https://address.domain.com")
+                        .payloadType("application/json")
+                        .payload(ImmutableMap.of("field", "value"))
+                        .headers(ImmutableMap.of(
+                                "Custom-Header", "CUSTOM-VALUE",
+                                "Custom-Header-2", "CUSTOM-VALUE-2"))
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void create_form_webhook() {
+        // given
+        executor
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_create_webhook_form_request.txt")),
+                        result("/AlertChannels_create_webhook_form_response.json"));
+
+        // when
+        AlertsChannel channel = testee.create(AlertsChannel.builder()
+                .name("Test Webhook Channel")
+                .type("webhook")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .baseUrl("https://address.domain.com")
+                        .authUsername("test")
+                        .authPassword("pass")
+                        .payloadType("application/x-www-form-urlencoded")
+                        .payload(ImmutableMap.of(
+                                "current_state", "acknowledged",
+                                "account_name", "$ACCOUNT_NAME"))
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+
+        // then
+        assertThat(channel).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Webhook Channel")
+                .type("webhook")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .baseUrl("https://address.domain.com")
+                        .authUsername("test")
+                        .payloadType("application/x-www-form-urlencoded")
+                        .payload(ImmutableMap.of(
+                                "current_state", "acknowledged",
+                                "account_name", "$ACCOUNT_NAME"))
+                        .build())
+                .links(new AlertsChannelLinks(new ArrayList<>()))
+                .build());
+    }
+
+    @Test
+    public void create_shouldThrow_onError() {
+        // given
+        executor
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_create_email_request.txt")),
+                        result("/AlertChannels_create_error.json"));
+
+        // then
+        assertThatThrownBy(() -> testee.create(AlertsChannel.builder()
+                .name("Test Email Channel")
+                .type("email")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .recipients("email@domain.com,other@domain.com")
+                        .build())
+                .build())).isInstanceOf(GraphqlApiError.class);
+    }
+
+    @Test
+    public void delete() {
+        // given
+        executor
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                        result("/AlertChannels_getById_email_response.json"))
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_delete_request.txt")),
+                        result("/AlertChannels_delete_response.json"));
+
+        // when
+        AlertsChannel channel = testee.delete(1111111);
+
+        // then
+        assertThat(channel).usingRecursiveComparison().isEqualTo(AlertsChannel.builder()
+                .id(1111111)
+                .name("Test Email Channel")
+                .type("email")
+                .configuration(AlertsChannelConfiguration.builder()
+                        .recipients("email@domain.com,other@domain.com")
+                        .includeJsonAttachment(true)
+                        .build())
+                .links(new AlertsChannelLinks(ImmutableList.of(1234567)))
+                .build());
+    }
+
+    @Test
+    public void delete_shouldThrow_onError() {
+        // given
+        executor
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertChannels_getById_request.txt")),
+                        result("/AlertChannels_getById_email_response.json"))
+                .addScenario(
+                        Query.of(fromJson("/AlertChannels_delete_request.txt")),
+                        result("/AlertChannels_delete_error.json"));
+
+        // then
+        assertThatThrownBy(() -> testee.delete(1111111))
+                .isInstanceOf(GraphqlApiError.class);
+    }
+
+    private static Result result(String fileName) {
+        return fromJson(fileName, Result.class);
+    }
+}

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsNrqlConditionsApiTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsNrqlConditionsApiTest.java
@@ -1,0 +1,377 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Expiration;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Signal;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.Terms;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.AlertsNrqlCondition;
+import com.ocadotechnology.newrelic.apiclient.model.conditions.nrql.Nrql;
+import com.ocadotechnology.newrelic.graphql.apiclient.GraphqlApiError;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.testutil.QueryExecutorMock;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.ocadotechnology.newrelic.graphql.apiclient.internal.testutil.TestResources.fromJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class GraphqlAlertsNrqlConditionsApiTest {
+
+    private static final int ACCOUNT_ID = 12345678;
+    private static final int POLICY_ID = 7654321;
+
+    private final QueryExecutorMock executor = new QueryExecutorMock();
+    private GraphqlAlertsNrqlConditionsApi testee;
+
+    @Before
+    public void setUp() {
+        testee = new GraphqlAlertsNrqlConditionsApi(executor, ACCOUNT_ID);
+    }
+
+    @Test
+    public void list() {
+        // given
+        executor
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertsNrqlConditions_list_request_part1.txt")),
+                        result("/AlertsNrqlConditions_list_response_part1.json"))
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertsNrqlConditions_list_request_part2.txt")),
+                        result("/AlertsNrqlConditions_list_response_part2.json"));
+
+        // when
+        List<AlertsNrqlCondition> conditions = testee.list(POLICY_ID);
+
+        // then
+        assertThat(conditions).hasSize(2);
+        assertThat(conditions).containsExactly(
+                AlertsNrqlCondition.builder()
+                        .id(11111111)
+                        .name("Test NRQL Condition 1")
+                        .nrql(new Nrql("SELECT count(*) from `test1:test-event`"))
+                        .enabled(true)
+                        .expiration(Expiration.builder()
+                                .closeViolationsOnExpiration(true)
+                                .expirationDuration("900")
+                                .openViolationOnExpiration(false)
+                                .build())
+                        .signal(Signal.builder()
+                                .aggregationDelay("120")
+                                .aggregationMethod("EVENT_FLOW")
+                                .aggregationTimer(null)
+                                .aggregationWindow("60")
+                                .fillOption("static")
+                                .fillValue("0")
+                                .build())
+                        .terms(ImmutableList.of(
+                                Terms.builder()
+                                        .operator("below")
+                                        .priority("critical")
+                                        .threshold("1")
+                                        .duration("5")
+                                        .timeFunction("all")
+                                        .build()
+                        ))
+                        .valueFunction("single_value")
+                        .build(),
+                AlertsNrqlCondition.builder()
+                        .id(22222222)
+                        .name("Test NRQL Condition 2")
+                        .nrql(new Nrql("SELECT count(*) from `test2:test-event`"))
+                        .enabled(true)
+                        .expiration(Expiration.builder()
+                                .closeViolationsOnExpiration(false)
+                                .expirationDuration(null)
+                                .openViolationOnExpiration(false)
+                                .build())
+                        .signal(Signal.builder()
+                                .aggregationDelay("120")
+                                .aggregationMethod("EVENT_FLOW")
+                                .aggregationTimer("240")
+                                .aggregationWindow("60")
+                                .fillOption("none")
+                                .fillValue(null)
+                                .build())
+                        .terms(ImmutableList.of(
+                                Terms.builder()
+                                        .operator("above_or_equals")
+                                        .priority("critical")
+                                        .threshold("1")
+                                        .duration("1")
+                                        .timeFunction("any")
+                                        .build()
+                        ))
+                        .valueFunction("sum")
+                        .build()
+        );
+    }
+
+    @Test
+    public void create() {
+        // given
+        executor.addScenario(
+                Query.of(fromJson("/AlertsNrqlConditions_create_request.txt")),
+                result("/AlertsNrqlConditions_create_response.json"));
+
+        AlertsNrqlCondition requestedCondition = AlertsNrqlCondition.builder()
+                .id(11111111)
+                .name("Test NRQL Condition")
+                .nrql(new Nrql("SELECT count(*) from `test:test-event`"))
+                .enabled(true)
+                .expiration(Expiration.builder()
+                        .closeViolationsOnExpiration(false)
+                        .expirationDuration("60")
+                        .openViolationOnExpiration(false)
+                        .build())
+                .signal(Signal.builder()
+                        .aggregationDelay("120")
+                        .aggregationMethod("CADENCE")
+                        .aggregationTimer(null)
+                        .aggregationWindow("60")
+                        .fillOption("none")
+                        .fillValue(null)
+                        .build())
+                .terms(ImmutableList.of(
+                        Terms.builder()
+                                .operator("above_or_equals")
+                                .priority("critical")
+                                .threshold("1")
+                                .duration("1")
+                                .timeFunction("any")
+                                .build()
+                ))
+                .valueFunction("single_value")
+                .build();
+        // when
+        AlertsNrqlCondition condition = testee.create(POLICY_ID, requestedCondition);
+
+        // then
+        assertThat(condition).isEqualTo(requestedCondition);
+    }
+
+    @Test
+    public void create_shouldThrow_onError() {
+        // given
+        executor.addScenario(
+                Query.of(fromJson("/AlertsNrqlConditions_create_request.txt")),
+                result("/AlertsNrqlConditions_create_error.json"));
+
+        AlertsNrqlCondition requestedCondition = AlertsNrqlCondition.builder()
+                .id(11111111)
+                .name("Test NRQL Condition")
+                .nrql(new Nrql("SELECT count(*) from `test:test-event`"))
+                .enabled(true)
+                .expiration(Expiration.builder()
+                        .closeViolationsOnExpiration(false)
+                        .expirationDuration("60")
+                        .openViolationOnExpiration(false)
+                        .build())
+                .signal(Signal.builder()
+                        .aggregationDelay("120")
+                        .aggregationMethod("cadence")
+                        .aggregationTimer(null)
+                        .aggregationWindow("60")
+                        .fillOption("none")
+                        .fillValue(null)
+                        .build())
+                .terms(ImmutableList.of(
+                        Terms.builder()
+                                .operator("above_or_equals")
+                                .priority("critical")
+                                .threshold("1")
+                                .duration("1")
+                                .timeFunction("any")
+                                .build()
+                ))
+                .valueFunction("single_value")
+                .build();
+
+        // then
+        assertThatThrownBy(() ->
+                testee.create(POLICY_ID, requestedCondition)
+        ).isInstanceOf(GraphqlApiError.class);
+    }
+
+    @Test
+    public void delete() {
+        // given
+        executor
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertsNrqlConditions_list_request_part1.txt")),
+                        result("/AlertsNrqlConditions_list_response_part1.json"))
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertsNrqlConditions_list_request_part2.txt")),
+                        result("/AlertsNrqlConditions_list_response_part2.json"))
+                .addScenario(
+                        Query.of(fromJson("/AlertsNrqlConditions_delete_request.txt")),
+                        result("/AlertsNrqlConditions_delete_response.json"));
+
+        AlertsNrqlCondition expectedCondition = AlertsNrqlCondition.builder()
+                .id(11111111)
+                .name("Test NRQL Condition 1")
+                .nrql(new Nrql("SELECT count(*) from `test1:test-event`"))
+                .enabled(true)
+                .expiration(Expiration.builder()
+                        .closeViolationsOnExpiration(true)
+                        .expirationDuration("900")
+                        .openViolationOnExpiration(false)
+                        .build())
+                .signal(Signal.builder()
+                        .aggregationDelay("120")
+                        .aggregationMethod("EVENT_FLOW")
+                        .aggregationTimer(null)
+                        .aggregationWindow("60")
+                        .fillOption("static")
+                        .fillValue("0")
+                        .build())
+                .terms(ImmutableList.of(
+                        Terms.builder()
+                                .operator("below")
+                                .priority("critical")
+                                .threshold("1")
+                                .duration("5")
+                                .timeFunction("all")
+                                .build()
+                ))
+                .valueFunction("single_value")
+                .build();
+
+        // when
+        AlertsNrqlCondition deleted = testee.delete(POLICY_ID, 11111111);
+
+        // then
+        assertThat(deleted).isEqualTo(expectedCondition);
+    }
+
+    @Test
+    public void delete_shouldThrow_onError() {
+        // given
+        executor
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertsNrqlConditions_list_request_part1.txt")),
+                        result("/AlertsNrqlConditions_list_response_part1.json"))
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertsNrqlConditions_list_request_part2.txt")),
+                        result("/AlertsNrqlConditions_list_response_part2.json"))
+                .addScenario(
+                        Query.of(fromJson("/AlertsNrqlConditions_delete_request.txt")),
+                        result("/AlertsNrqlConditions_delete_error.json"));
+
+        // then
+        assertThatThrownBy(() ->
+                testee.delete(POLICY_ID, 11111111)
+        ).isInstanceOf(GraphqlApiError.class);
+    }
+
+    @Test
+    public void delete_shouldThrow_onNotFound() {
+        // given
+        executor
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertsNrqlConditions_list_request_part1.txt")),
+                        result("/AlertsNrqlConditions_list_response_part1.json"))
+                .addScenario(
+                        Query.wrapped(fromJson("/AlertsNrqlConditions_list_request_part2.txt")),
+                        result("/AlertsNrqlConditions_list_response_part2.json"));
+
+        // then
+        assertThatThrownBy(() ->
+                testee.delete(POLICY_ID, 99999999)
+        ).isInstanceOf(GraphqlApiError.class);
+    }
+
+    @Test
+    public void update() {
+        // given
+        executor.addScenario(
+                Query.of(fromJson("/AlertsNrqlConditions_update_request.txt")),
+                result("/AlertsNrqlConditions_update_response.json"));
+
+        AlertsNrqlCondition requestedCondition = AlertsNrqlCondition.builder()
+                .id(11111111)
+                .name("Test NRQL Condition UPDATED")
+                .nrql(new Nrql("SELECT count(*) from `test:test-event`"))
+                .enabled(true)
+                .expiration(Expiration.builder()
+                        .closeViolationsOnExpiration(false)
+                        .expirationDuration("60")
+                        .openViolationOnExpiration(false)
+                        .build())
+                .signal(Signal.builder()
+                        .aggregationDelay("120")
+                        .aggregationMethod("CADENCE")
+                        .aggregationTimer(null)
+                        .aggregationWindow("60")
+                        .fillOption("none")
+                        .fillValue(null)
+                        .build())
+                .terms(ImmutableList.of(
+                        Terms.builder()
+                                .operator("above_or_equals")
+                                .priority("critical")
+                                .threshold("1")
+                                .duration("1")
+                                .timeFunction("any")
+                                .build()
+                ))
+                .valueFunction("single_value")
+                .build();
+        // when
+        AlertsNrqlCondition condition = testee.update(11111111, requestedCondition);
+
+        // then
+        assertThat(condition).isEqualTo(requestedCondition);
+    }
+
+    @Test
+    public void update_shouldThrow_onError() {
+        // given
+        executor.addScenario(
+                Query.of(fromJson("/AlertsNrqlConditions_update_request.txt")),
+                result("/AlertsNrqlConditions_update_error.json"));
+
+        AlertsNrqlCondition requestedCondition = AlertsNrqlCondition.builder()
+                .id(11111111)
+                .name("Test NRQL Condition UPDATED")
+                .nrql(new Nrql("SELECT count(*) from `test:test-event`"))
+                .enabled(true)
+                .expiration(Expiration.builder()
+                        .closeViolationsOnExpiration(false)
+                        .expirationDuration("60")
+                        .openViolationOnExpiration(false)
+                        .build())
+                .signal(Signal.builder()
+                        .aggregationDelay("120")
+                        .aggregationMethod("CADENCE")
+                        .aggregationTimer(null)
+                        .aggregationWindow("60")
+                        .fillOption("none")
+                        .fillValue(null)
+                        .build())
+                .terms(ImmutableList.of(
+                        Terms.builder()
+                                .operator("above_or_equals")
+                                .priority("critical")
+                                .threshold("1")
+                                .duration("1")
+                                .timeFunction("any")
+                                .build()
+                ))
+                .valueFunction("single_value")
+                .build();
+
+        // then
+        assertThatThrownBy(() ->
+                testee.update(11111111, requestedCondition)
+        ).isInstanceOf(GraphqlApiError.class);
+        ;
+    }
+
+    private static Result result(String fileName) {
+        return fromJson(fileName, Result.class);
+    }
+}

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsPoliciesApiTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/GraphqlAlertsPoliciesApiTest.java
@@ -1,0 +1,206 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.ocadotechnology.newrelic.apiclient.model.policies.AlertsPolicy;
+import com.ocadotechnology.newrelic.apiclient.model.policies.AlertsPolicyChannels;
+import com.ocadotechnology.newrelic.graphql.apiclient.GraphqlApiError;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.testutil.QueryExecutorMock;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Result;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static com.ocadotechnology.newrelic.graphql.apiclient.internal.testutil.TestResources.fromJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class GraphqlAlertsPoliciesApiTest {
+    private static final int ACCOUNT_ID = 12345678;
+
+    private final QueryExecutorMock executor = new QueryExecutorMock();
+    private GraphqlAlertsPoliciesApi testee;
+
+    @Before
+    public void setUp() {
+        testee = new GraphqlAlertsPoliciesApi(executor, ACCOUNT_ID);
+    }
+
+    @Test
+    public void getByName_shouldReturnPolicy() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertPolicies_getByName_request.txt")),
+                result("/AlertPolicies_getByName_singleResponse.json"));
+
+        // when
+        Optional<AlertsPolicy> policyOptional = testee.getByName("Test Policy");
+
+        // then
+        assertThat(policyOptional).isNotEmpty();
+        assertThat(policyOptional.get()).usingRecursiveComparison().isEqualTo(AlertsPolicy.builder()
+                .id(7654321)
+                .name("Test Policy")
+                .incidentPreference("PER_CONDITION")
+                .build());
+    }
+
+    @Test
+    public void getByName_shouldReturnPolicy_whenClientReturnsNotUniqueResult() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertPolicies_getByName_request.txt")),
+                result("/AlertPolicies_getByName_multiResponse.json"));
+
+        // when
+        Optional<AlertsPolicy> policyOptional = testee.getByName("Test Policy");
+
+        // then
+        assertThat(policyOptional).isNotEmpty();
+        assertThat(policyOptional.get()).usingRecursiveComparison().isEqualTo(AlertsPolicy.builder()
+                .id(7654321)
+                .name("Test Policy")
+                .incidentPreference("PER_CONDITION")
+                .build());
+    }
+
+    @Test
+    public void getById_shouldReturnPolicy() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertPolicies_getById_request.txt")),
+                result("/AlertPolicies_getById_response.json"));
+
+        // when
+        Optional<AlertsPolicy> policyOptional = testee.getById(7654321);
+
+        // then
+        assertThat(policyOptional).isNotEmpty();
+        assertThat(policyOptional.get()).usingRecursiveComparison().isEqualTo(AlertsPolicy.builder()
+                .id(7654321)
+                .name("Test Policy")
+                .incidentPreference("PER_CONDITION")
+                .build());
+    }
+
+    @Test
+    public void getById_shouldReturnEmpty_whenPolicyNotFound() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertPolicies_getById_request.txt")),
+                result("/AlertPolicies_getById_notFound.json"));
+
+        // when
+        Optional<AlertsPolicy> policyOptional = testee.getById(7654321);
+
+        // then
+        assertThat(policyOptional).isEmpty();
+    }
+
+    @Test
+    public void getById_shouldThrow_onError() {
+        // given
+        executor.addScenario(
+                Query.wrapped(fromJson("/AlertPolicies_getById_request.txt")),
+                result("/AlertPolicies_getById_accessDenied.json"));
+
+        // then
+        assertThatThrownBy(() -> testee.getById(7654321)).isInstanceOf(GraphqlApiError.class);
+    }
+
+    @Test
+    public void create() {
+        // given
+        executor.addScenario(
+                Query.of(fromJson("/AlertPolicies_create_request.txt")),
+                result("/AlertPolicies_create_response.json"));
+
+        // when
+        AlertsPolicy policy = testee.create(AlertsPolicy.builder()
+                .name("Test Policy")
+                .incidentPreference("PER_CONDITION")
+                .build());
+
+        // then
+        assertThat(policy).usingRecursiveComparison().isEqualTo(AlertsPolicy.builder()
+                .id(7654321)
+                .name("Test Policy")
+                .incidentPreference("PER_CONDITION")
+                .build());
+    }
+
+    @Test
+    public void delete() {
+        // given
+        executor.addScenario(
+                        Query.wrapped(fromJson("/AlertPolicies_getById_request.txt")),
+                        result("/AlertPolicies_getById_response.json"))
+                .addScenario(
+                        Query.of(fromJson("/AlertPolicies_delete_request.txt")),
+                        result("/AlertPolicies_delete_response.json"));
+
+        // when
+        AlertsPolicy policy = testee.delete(7654321);
+
+        // then
+        assertThat(policy).usingRecursiveComparison().isEqualTo(AlertsPolicy.builder()
+                .id(7654321)
+                .name("Test Policy")
+                .incidentPreference("PER_CONDITION")
+                .build());
+    }
+
+    @Test
+    public void delete_shouldThrow_whenNotFound() {
+        // given
+        executor.addScenario(
+                        Query.wrapped(fromJson("/AlertPolicies_getById_request.txt")),
+                        result("/AlertPolicies_getById_notFound.json"))
+                .addScenario(
+                        Query.of(fromJson("/AlertPolicies_delete_request.txt")),
+                        result("/AlertPolicies_delete_response.json"));
+
+        // then
+        assertThatThrownBy(() -> testee.delete(7654321)).isInstanceOf(GraphqlApiError.class);
+    }
+
+    @Test
+    public void updatePolicyChannels() {
+        // given
+        executor.addScenario(
+                Query.of(fromJson("/AlertPolicies_updateChannels_request.txt")),
+                result("/AlertPolicies_updateChannels_response.json"));
+
+        // when
+        AlertsPolicyChannels channels = testee.updateChannels(AlertsPolicyChannels.builder()
+                .policyId(7654321)
+                .channelIds(ImmutableList.of(1111111, 2222222))
+                .build());
+
+        // then
+        assertThat(channels).usingRecursiveComparison().isEqualTo(AlertsPolicyChannels.builder()
+                .policyId(7654321)
+                .channelIds(ImmutableList.of(1111111, 2222222))
+                .build());
+    }
+
+    @Test
+    public void updatePolicyChannels_shouldThrow_onError() {
+        // given
+        executor.addScenario(
+                Query.of(fromJson("/AlertPolicies_updateChannels_request.txt")),
+                result("/AlertPolicies_updateChannels_error.json"));
+
+        // then
+        assertThatThrownBy(() -> testee.updateChannels(AlertsPolicyChannels.builder()
+                .policyId(7654321)
+                .channelIds(ImmutableList.of(1111111, 2222222))
+                .build())
+        ).isInstanceOf(GraphqlApiError.class);
+    }
+
+    private static Result result(String fileName) {
+        return fromJson(fileName, Result.class);
+    }
+}

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/testutil/QueryExecutorMock.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/testutil/QueryExecutorMock.java
@@ -1,0 +1,27 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.testutil;
+
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.QueryExecutor;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Query;
+import com.ocadotechnology.newrelic.graphql.apiclient.internal.transport.Result;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+public class QueryExecutorMock implements QueryExecutor {
+    private final Map<Query, Result> resultsByQuery = new HashMap<>();
+
+    @Override
+    public Result execute(Query query) {
+        return Optional.ofNullable(resultsByQuery.get(query))
+                .orElseThrow(() -> new UnsupportedOperationException(format("No scenario found for query:'\n%s\n'", query)));
+    }
+
+
+    public QueryExecutorMock addScenario(Query query, Result result) {
+        resultsByQuery.put(query, result);
+        return this;
+    }
+}

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/testutil/TestResources.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/testutil/TestResources.java
@@ -1,0 +1,34 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.testutil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.*;
+
+public class TestResources {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static InputStream inputStream(String fileName) {
+        return TestResources.class.getResourceAsStream(fileName);
+    }
+
+    public static <T> T fromJson(String fileName, Class<T> clazz) {
+        try {
+            return OBJECT_MAPPER.readValue(new InputStreamReader(inputStream(fileName)), clazz);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String fromJson(String fileName) {
+        try (InputStream inputStream = inputStream(fileName)) {
+            BufferedInputStream bis = new BufferedInputStream(inputStream);
+            ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            for (int result = bis.read(); result != -1; result = bis.read()) {
+                buf.write((byte) result);
+            }
+            return buf.toString("UTF-8");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/JavaLikeEnumTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/JavaLikeEnumTest.java
@@ -1,0 +1,30 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class JavaLikeEnumTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void shouldSerialize() throws Exception {
+        assertThat(serialize("enum", "value")).isEqualTo("{\"enum\":value}");
+        assertThat(serialize("enum", "fancy0 @val ^#ue_ ")).isEqualTo("{\"enum\":fancy0value_}");
+    }
+
+    @Test
+    public void shouldNotSerialize() throws Exception {
+        assertThatThrownBy(() -> serialize("enum", null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> serialize("enum", "")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> serialize("enum", "  ")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> serialize("enum", "!@#")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private String serialize(String name, String value) throws Exception {
+        return objectMapper.writeValueAsString(ImmutableMap.of(name, new JavaLikeEnum(value)));
+    }
+}

--- a/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/ResultTest.java
+++ b/newrelic-api-client/src/test/java/com/ocadotechnology/newrelic/graphql/apiclient/internal/transport/ResultTest.java
@@ -1,0 +1,24 @@
+package com.ocadotechnology.newrelic.graphql.apiclient.internal.transport;
+
+import org.junit.Test;
+
+import static com.ocadotechnology.newrelic.graphql.apiclient.internal.testutil.TestResources.fromJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResultTest {
+    @Test
+    public void shouldReturnTrueIfErrorsPresent() {
+        assertThat(result("/AlertPolicies_getById_response.json").hasErrors()).isFalse();
+        assertThat(result("/AlertPolicies_getById_response.json").notFound()).isFalse();
+
+        assertThat(result("/AlertPolicies_getById_accessDenied.json").hasErrors()).isTrue();
+        assertThat(result("/AlertPolicies_getById_accessDenied.json").notFound()).isFalse();
+
+        assertThat(result("/AlertPolicies_getById_notFound.json").hasErrors()).isTrue();
+        assertThat(result("/AlertPolicies_getById_notFound.json").notFound()).isTrue();
+    }
+
+    private Result result(String fileName) {
+        return fromJson(fileName, Result.class);
+    }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_email_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_email_request.txt
@@ -1,0 +1,74 @@
+mutation {
+  alertsNotificationChannelCreate(accountId:12345678 notificationChannel:{email:{name:"Test Email Channel",emails:["email@domain.com","other@domain.com"],includeJson:false}}) {
+    error {
+      description
+      errorType
+    }
+    notificationChannel {
+      ... on AlertsEmailNotificationChannel {
+        id
+        name
+        type
+        config {
+          emails
+          includeJson
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsPagerDutyNotificationChannel {
+        id
+        name
+        type
+        config {
+          apiKey
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsSlackNotificationChannel {
+        id
+        name
+        type
+        config {
+          teamChannel
+          url
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsWebhookNotificationChannel {
+        id
+        name
+        type
+        config {
+          baseUrl
+          basicAuth {
+            username
+            password
+          }
+          customHttpHeaders {
+            name
+            value
+          }
+          customPayloadBody
+          customPayloadType
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_email_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_email_response.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "alertsNotificationChannelCreate": {
+      "error": null,
+      "notificationChannel": {
+        "associatedPolicies": {
+          "policies": []
+        },
+        "config": {
+          "emails": [
+            "email@domain.com",
+            "other@domain.com"
+          ],
+          "includeJson": false
+        },
+        "id": "1111111",
+        "name": "Test Email Channel",
+        "type": "EMAIL"
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_error.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_error.json
@@ -1,0 +1,13 @@
+{
+  "errors": [
+    {
+      "locations": [
+        {
+          "column": 52,
+          "line": 2
+        }
+      ],
+      "message": "Argument \"notificationChannel\" has invalid value."
+    }
+  ]
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_pagerduty_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_pagerduty_request.txt
@@ -1,0 +1,74 @@
+mutation {
+  alertsNotificationChannelCreate(accountId:12345678 notificationChannel:{pagerDuty:{name:"Test PagerDuty Channel",apiKey:"abcdefghijklmnopqRSTUVWXYZ"}}) {
+    error {
+      description
+      errorType
+    }
+    notificationChannel {
+      ... on AlertsEmailNotificationChannel {
+        id
+        name
+        type
+        config {
+          emails
+          includeJson
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsPagerDutyNotificationChannel {
+        id
+        name
+        type
+        config {
+          apiKey
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsSlackNotificationChannel {
+        id
+        name
+        type
+        config {
+          teamChannel
+          url
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsWebhookNotificationChannel {
+        id
+        name
+        type
+        config {
+          baseUrl
+          basicAuth {
+            username
+            password
+          }
+          customHttpHeaders {
+            name
+            value
+          }
+          customPayloadBody
+          customPayloadType
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_pagerduty_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_pagerduty_response.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "alertsNotificationChannelCreate": {
+      "error": null,
+      "notificationChannel": {
+        "associatedPolicies": {
+          "policies": []
+        },
+        "config": {
+          "apiKey": "*****************RSTUVWXYZ"
+        },
+        "id": "1111111",
+        "name": "Test PagerDuty Channel",
+        "type": "PAGERDUTY"
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_slack_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_slack_request.txt
@@ -1,0 +1,74 @@
+mutation {
+  alertsNotificationChannelCreate(accountId:12345678 notificationChannel:{slack:{name:"Test Slack Channel",teamChannel:"the channel",url:"https://domain.com/slack"}}) {
+    error {
+      description
+      errorType
+    }
+    notificationChannel {
+      ... on AlertsEmailNotificationChannel {
+        id
+        name
+        type
+        config {
+          emails
+          includeJson
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsPagerDutyNotificationChannel {
+        id
+        name
+        type
+        config {
+          apiKey
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsSlackNotificationChannel {
+        id
+        name
+        type
+        config {
+          teamChannel
+          url
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsWebhookNotificationChannel {
+        id
+        name
+        type
+        config {
+          baseUrl
+          basicAuth {
+            username
+            password
+          }
+          customHttpHeaders {
+            name
+            value
+          }
+          customPayloadBody
+          customPayloadType
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_slack_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_slack_response.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "alertsNotificationChannelCreate": {
+      "error": null,
+      "notificationChannel": {
+        "config": {
+          "teamChannel": "the channel",
+          "url": "***************om/slack"
+        },
+        "id": "1111111",
+        "name": "Test Slack Channel",
+        "type": "SLACK"
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_webhook_form_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_webhook_form_request.txt
@@ -1,0 +1,74 @@
+mutation {
+  alertsNotificationChannelCreate(accountId:12345678 notificationChannel:{webhook:{name:"Test Webhook Channel",baseUrl:"https://address.domain.com",basicAuth:{username:"test",password:"pass"},customPayloadType:FORM,customPayloadBody:"current_state=acknowledged\naccount_name=$ACCOUNT_NAME"}}) {
+    error {
+      description
+      errorType
+    }
+    notificationChannel {
+      ... on AlertsEmailNotificationChannel {
+        id
+        name
+        type
+        config {
+          emails
+          includeJson
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsPagerDutyNotificationChannel {
+        id
+        name
+        type
+        config {
+          apiKey
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsSlackNotificationChannel {
+        id
+        name
+        type
+        config {
+          teamChannel
+          url
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsWebhookNotificationChannel {
+        id
+        name
+        type
+        config {
+          baseUrl
+          basicAuth {
+            username
+            password
+          }
+          customHttpHeaders {
+            name
+            value
+          }
+          customPayloadBody
+          customPayloadType
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_webhook_form_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_webhook_form_response.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "alertsNotificationChannelCreate": {
+      "error": null,
+      "notificationChannel": {
+        "associatedPolicies": {
+          "policies": []
+        },
+        "config": {
+          "baseUrl": "https://address.domain.com",
+          "basicAuth": {
+            "password": "**ss",
+            "username": "test"
+          },
+          "customHttpHeaders": [],
+          "customPayloadBody": "current_state=acknowledged\naccount_name=$ACCOUNT_NAME",
+          "customPayloadType": "FORM"
+        },
+        "id": "1111111",
+        "name": "Test Webhook Channel",
+        "type": "WEBHOOK"
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_webhook_json_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_webhook_json_request.txt
@@ -1,0 +1,74 @@
+mutation {
+  alertsNotificationChannelCreate(accountId:12345678 notificationChannel:{webhook:{name:"Test Webhook Channel",baseUrl:"https://address.domain.com",customPayloadType:JSON,customHttpHeaders:[{name:"Custom-Header",value:"CUSTOM-VALUE"},{name:"Custom-Header-2",value:"CUSTOM-VALUE-2"}],customPayloadBody:"{\"field\":\"value\"}"}}) {
+    error {
+      description
+      errorType
+    }
+    notificationChannel {
+      ... on AlertsEmailNotificationChannel {
+        id
+        name
+        type
+        config {
+          emails
+          includeJson
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsPagerDutyNotificationChannel {
+        id
+        name
+        type
+        config {
+          apiKey
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsSlackNotificationChannel {
+        id
+        name
+        type
+        config {
+          teamChannel
+          url
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+      ... on AlertsWebhookNotificationChannel {
+        id
+        name
+        type
+        config {
+          baseUrl
+          basicAuth {
+            username
+            password
+          }
+          customHttpHeaders {
+            name
+            value
+          }
+          customPayloadBody
+          customPayloadType
+        }
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_create_webhook_json_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_create_webhook_json_response.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "alertsNotificationChannelCreate": {
+      "error": null,
+      "notificationChannel": {
+        "associatedPolicies": {
+          "policies": []
+        },
+        "config": {
+          "baseUrl": "https://address.domain.com",
+          "basicAuth": null,
+          "customHttpHeaders": [
+            {
+              "name": "Custom-Header",
+              "value": "CUSTOM-VALUE"
+            },
+            {
+              "name": "Custom-Header-2",
+              "value": "CUSTOM-VALUE-2"
+            }
+          ],
+          "customPayloadBody": "{\"field\":\"value\"}",
+          "customPayloadType": "JSON"
+        },
+        "id": "1111111",
+        "name": "Test Webhook Channel",
+        "type": "WEBHOOK"
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_deleteFromPolicy_error.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_deleteFromPolicy_error.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "alertsNotificationChannelsRemoveFromPolicy": {
+      "errors": [
+        {
+          "description": "Unable to find the policy with ID 7654321",
+          "errorType": "NOT_FOUND_ERROR",
+          "notificationChannelId": "1111111"
+        }
+      ],
+      "notificationChannels": []
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_deleteFromPolicy_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_deleteFromPolicy_request.txt
@@ -1,0 +1,12 @@
+mutation {
+  alertsNotificationChannelsRemoveFromPolicy(accountId:12345678 policyId:"7654321" notificationChannelIds:"1111111") {
+    notificationChannels {
+      id
+    }
+    errors {
+      description
+      errorType
+      notificationChannelId
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_deleteFromPolicy_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_deleteFromPolicy_response.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "alertsNotificationChannelsRemoveFromPolicy": {
+      "errors": [],
+      "notificationChannels": [
+        {
+          "id": "1111111"
+        }
+      ],
+      "policyId": "7654321"
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_delete_error.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_delete_error.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "alertsNotificationChannelDelete": {
+      "error": {
+        "description": "Not Found",
+        "errorType": "NOT_FOUND_ERROR",
+        "notificationChannelId": "1111111"
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_delete_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_delete_request.txt
@@ -1,0 +1,9 @@
+mutation {
+  alertsNotificationChannelDelete(accountId:12345678 id:"1111111") {
+    error {
+      description
+      errorType
+      notificationChannelId
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_delete_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_delete_response.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "alertsNotificationChannelDelete": {
+      "error": null
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_getById_email_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_getById_email_response.json
@@ -1,0 +1,29 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "notificationChannel": {
+            "associatedPolicies": {
+              "policies": [
+                {
+                  "id": "1234567"
+                }
+              ]
+            },
+            "config": {
+              "emails": [
+                "email@domain.com",
+                "other@domain.com"
+              ],
+              "includeJson": true
+            },
+            "id": "1111111",
+            "name": "Test Email Channel",
+            "type": "EMAIL"
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_getById_notFound.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_getById_notFound.json
@@ -1,0 +1,32 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "notificationChannel": null
+        }
+      }
+    }
+  },
+  "errors": [
+    {
+      "extensions": {
+        "code": "BAD_USER_INPUT",
+        "errorClass": "BAD_USER_INPUT"
+      },
+      "locations": [
+        {
+          "column": 7,
+          "line": 4
+        }
+      ],
+      "message": "Not Found",
+      "path": [
+        "actor",
+        "account",
+        "alerts",
+        "notificationChannel"
+      ]
+    }
+  ]
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_getById_pagerduty_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_getById_pagerduty_response.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "notificationChannel": {
+            "associatedPolicies": {
+              "policies": []
+            },
+            "config": {
+              "apiKey": "*********************abcdefghijk"
+            },
+            "id": "1111111",
+            "name": "Test Pagerduty Channel",
+            "type": "PAGERDUTY"
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_getById_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_getById_request.txt
@@ -1,0 +1,53 @@
+actor {
+  account(id:12345678) {
+    alerts {
+      notificationChannel(id:"1111111") {
+        id
+        name
+        type
+        associatedPolicies {
+          policies {
+            id
+          }
+        }
+        ... on AlertsEmailNotificationChannel {
+          config {
+            emails
+            includeJson
+          }
+        }
+        ... on AlertsSlackNotificationChannel {
+          config {
+            teamChannel
+            url
+          }
+        }
+        ... on AlertsPagerDutyNotificationChannel {
+          config {
+            apiKey
+          }
+        }
+        ... on AlertsWebhookNotificationChannel {
+          config {
+            baseUrl
+            basicAuth {
+              username
+              password
+            }
+            customHttpHeaders {
+              name
+              value
+            }
+            customPayloadBody
+            customPayloadType
+          }
+        }
+        ... on AlertsUserNotificationChannel {
+          config {
+            userId
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_getById_slack_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_getById_slack_response.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "notificationChannel": {
+            "associatedPolicies": {
+              "policies": []
+            },
+            "config": {
+              "teamChannel": "test-slack-channel",
+              "url": "****************************************************99/ABCDEFGHIJKLMNOPQRSTUWXYZ"
+            },
+            "id": "1111111",
+            "name": "Test Slack Channel",
+            "type": "SLACK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_getById_user_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_getById_user_response.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "notificationChannel": {
+            "associatedPolicies": {
+              "policies": []
+            },
+            "config": {
+              "userId": "2111111111"
+            },
+            "id": "1111111",
+            "name": "Test User Channel",
+            "type": "USER"
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_getById_webhook_form_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_getById_webhook_form_response.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "notificationChannel": {
+            "associatedPolicies": {
+              "policies": []
+            },
+            "config": {
+              "baseUrl": "https://address.domain.com",
+              "basicAuth": {
+                "password": "**st",
+                "username": "test"
+              },
+              "customHttpHeaders": [],
+              "customPayloadBody": "current_state=acknowledged\naccount_name=$ACCOUNT_NAME",
+              "customPayloadType": "FORM"
+            },
+            "id": "1111111",
+            "name": "Test Webhook Channel",
+            "type": "WEBHOOK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_getById_webhook_json_response.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_getById_webhook_json_response.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "notificationChannel": {
+            "associatedPolicies": {
+              "policies": []
+            },
+            "config": {
+              "baseUrl": "https://address.domain.com",
+              "basicAuth": null,
+              "customHttpHeaders": [
+                {
+                  "name": "Custom-Header",
+                  "value": "CUSTOM-VALUE"
+                },
+                {
+                  "name": "Custom-Header-2",
+                  "value": "CUSTOM-VALUE-2"
+                }
+              ],
+              "customPayloadBody": "{\n  \"field\": \"value\"\n}",
+              "customPayloadType": "JSON"
+            },
+            "id": "1111111",
+            "name": "Test Webhook Channel",
+            "type": "WEBHOOK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_list_error.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_list_error.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "actor": {
+      "account": null
+    }
+  },
+  "errors": [
+    {
+      "extensions": {
+        "errorClass": "ACCESS_DENIED"
+      },
+      "locations": [
+        {
+          "column": 5,
+          "line": 3
+        }
+      ],
+      "message": "Access denied.",
+      "path": [
+        "actor",
+        "account"
+      ]
+    }
+  ]
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_list_request_part1.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_list_request_part1.txt
@@ -1,0 +1,56 @@
+actor {
+  account(id:12345678) {
+    alerts {
+      notificationChannels(cursor:"") {
+        nextCursor
+        channels {
+          id
+          name
+          type
+          associatedPolicies {
+            policies {
+              id
+            }
+          }
+          ... on AlertsEmailNotificationChannel {
+            config {
+              emails
+              includeJson
+            }
+          }
+          ... on AlertsSlackNotificationChannel {
+            config {
+              teamChannel
+              url
+            }
+          }
+          ... on AlertsPagerDutyNotificationChannel {
+            config {
+              apiKey
+            }
+          }
+          ... on AlertsWebhookNotificationChannel {
+            config {
+              baseUrl
+              basicAuth {
+                username
+                password
+              }
+              customHttpHeaders {
+                name
+                value
+              }
+              customPayloadBody
+              customPayloadType
+            }
+          }
+          ... on AlertsUserNotificationChannel {
+            config {
+              userId
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_list_request_part2.txt
+++ b/newrelic-api-client/src/test/resources/AlertChannels_list_request_part2.txt
@@ -1,0 +1,56 @@
+actor {
+  account(id:12345678) {
+    alerts {
+      notificationChannels(cursor:"123456abcdeFGHIJKLMNOP==:7899999999999999ZZzZzzZ=") {
+        nextCursor
+        channels {
+          id
+          name
+          type
+          associatedPolicies {
+            policies {
+              id
+            }
+          }
+          ... on AlertsEmailNotificationChannel {
+            config {
+              emails
+              includeJson
+            }
+          }
+          ... on AlertsSlackNotificationChannel {
+            config {
+              teamChannel
+              url
+            }
+          }
+          ... on AlertsPagerDutyNotificationChannel {
+            config {
+              apiKey
+            }
+          }
+          ... on AlertsWebhookNotificationChannel {
+            config {
+              baseUrl
+              basicAuth {
+                username
+                password
+              }
+              customHttpHeaders {
+                name
+                value
+              }
+              customPayloadBody
+              customPayloadType
+            }
+          }
+          ... on AlertsUserNotificationChannel {
+            config {
+              userId
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_list_response_part1.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_list_response_part1.json
@@ -1,0 +1,41 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "notificationChannels": {
+            "channels": [
+              {
+                "associatedPolicies": {
+                  "policies": []
+                },
+                "config": {
+                  "emails": [
+                    "mail@domain.com"
+                  ],
+                  "includeJson": false
+                },
+                "id": "1111111",
+                "name": "Test Email Channel",
+                "type": "EMAIL"
+              },
+              {
+                "associatedPolicies": {
+                  "policies": [
+                    {
+                      "id": "123456"
+                    }
+                  ]
+                },
+                "id": "2222222",
+                "name": "Test Webhook Channel",
+                "type": "WEBHOOK"
+              }
+            ],
+            "nextCursor": "123456abcdeFGHIJKLMNOP==:7899999999999999ZZzZzzZ="
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertChannels_list_response_part2.json
+++ b/newrelic-api-client/src/test/resources/AlertChannels_list_response_part2.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "notificationChannels": {
+            "channels": [
+              {
+                "associatedPolicies": {
+                  "policies": []
+                },
+                "id": "3333333",
+                "name": "Test Slack Channel",
+                "type": "SLACK"
+              }
+            ],
+            "nextCursor": null
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_create_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_create_request.txt
@@ -1,0 +1,7 @@
+mutation {
+  alertsPolicyCreate(accountId:12345678 policy:{name:"Test Policy",incidentPreference:PER_CONDITION}) {
+    id
+    name
+    incidentPreference
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_create_response.json
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_create_response.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "alertsPolicyCreate": {
+      "id": "7654321",
+      "incidentPreference": "PER_CONDITION",
+      "name": "Test Policy"
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_delete_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_delete_request.txt
@@ -1,0 +1,5 @@
+mutation {
+  alertsPolicyDelete(accountId:12345678 id:"7654321") {
+    id
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_delete_response.json
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_delete_response.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "alertsPolicyDelete": {
+      "id": "7654321"
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_getById_accessDenied.json
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_getById_accessDenied.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "actor": {
+      "account": null
+    }
+  },
+  "errors": [
+    {
+      "extensions": {
+        "errorClass": "ACCESS_DENIED"
+      },
+      "locations": [
+        {
+          "column": 5,
+          "line": 3
+        }
+      ],
+      "message": "Access denied.",
+      "path": [
+        "actor",
+        "account"
+      ]
+    }
+  ]
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_getById_notFound.json
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_getById_notFound.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "policy": null
+        }
+      }
+    }
+  },
+  "errors": [
+    {
+      "extensions": {
+        "code": "BAD_USER_INPUT",
+        "errorClass": "BAD_USER_INPUT"
+      },
+      "locations": [
+        {
+          "column": 7,
+          "line": 5
+        }
+      ],
+      "message": "Not Found",
+      "path": [
+        "actor",
+        "account",
+        "alerts",
+        "policy",
+        "id"
+      ]
+    }
+  ]
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_getById_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_getById_request.txt
@@ -1,0 +1,11 @@
+actor {
+  account(id:12345678) {
+    alerts {
+      policy(id:7654321) {
+        id
+        name
+        incidentPreference
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_getById_response.json
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_getById_response.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "policy": {
+            "id": "7654321",
+            "incidentPreference": "PER_CONDITION",
+            "name": "Test Policy"
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_getByName_multiResponse.json
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_getByName_multiResponse.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "policiesSearch": {
+            "policies": [
+              {
+                "id": "7654321",
+                "incidentPreference": "PER_CONDITION",
+                "name": "Test Policy"
+              },
+              {
+                "id": "1234567",
+                "incidentPreference": "PER_CONDITION",
+                "name": "Test Policy"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_getByName_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_getByName_request.txt
@@ -1,0 +1,13 @@
+actor {
+  account(id:12345678) {
+    alerts {
+      policiesSearch(searchCriteria:{name:"Test Policy"}) {
+        policies {
+          id
+          name
+          incidentPreference
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_getByName_singleResponse.json
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_getByName_singleResponse.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "policiesSearch": {
+            "policies": [
+              {
+                "id": "7654321",
+                "incidentPreference": "PER_CONDITION",
+                "name": "Test Policy"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_updateChannels_error.json
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_updateChannels_error.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "alertsNotificationChannelsAddToPolicy": {
+      "errors": [
+        {
+          "description": "Validation Failure",
+          "errorType": "BAD_USER_INPUT",
+          "notificationChannelId": "1111111"
+        }
+      ],
+      "notificationChannels": []
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_updateChannels_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_updateChannels_request.txt
@@ -1,0 +1,12 @@
+mutation {
+  alertsNotificationChannelsAddToPolicy(accountId:12345678 policyId:7654321 notificationChannelIds:[1111111, 2222222]) {
+    notificationChannels {
+      id
+    }
+    errors {
+      description
+      errorType
+      notificationChannelId
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertPolicies_updateChannels_response.json
+++ b/newrelic-api-client/src/test/resources/AlertPolicies_updateChannels_response.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "alertsNotificationChannelsAddToPolicy": {
+      "notificationChannels": [
+        {
+          "id": "1111111"
+        },
+        {
+          "id": "2222222"
+        }
+      ]
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_create_error.json
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_create_error.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "alertsNrqlConditionStaticCreate": null
+  },
+  "errors": [
+    {
+      "extensions": {
+        "errorClass": "ACCESS_DENIED"
+      },
+      "locations": [
+        {
+          "column": 3,
+          "line": 2
+        }
+      ],
+      "message": "Access restricted",
+      "path": [
+        "alertsNrqlConditionStaticCreate"
+      ]
+    }
+  ]
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_create_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_create_request.txt
@@ -1,0 +1,36 @@
+mutation {
+  alertsNrqlConditionStaticCreate(accountId:12345678 policyId:7654321 condition:{enabled:true,name:"Test NRQL Condition",nrql:{query:"SELECT count(*) from `test:test-event`"},expiration:{closeViolationsOnExpiration:false,openViolationOnExpiration:false,expirationDuration:60},signal:{aggregationDelay:120,aggregationMethod:CADENCE,aggregationWindow:60,fillOption:NONE},terms:[{operator:ABOVE_OR_EQUALS,priority:CRITICAL,threshold:1.0,thresholdDuration:60,thresholdOccurrences:AT_LEAST_ONCE}],valueFunction:SINGLE_VALUE}) {
+    id
+    name
+    enabled
+    runbookUrl
+    nrql {
+      query
+    }
+    signal {
+      aggregationDelay
+      aggregationMethod
+      aggregationTimer
+      aggregationWindow
+      evaluationDelay
+      fillOption
+      fillValue
+      slideBy
+    }
+    terms {
+      operator
+      priority
+      threshold
+      thresholdDuration
+      thresholdOccurrences
+    }
+    expiration {
+      closeViolationsOnExpiration
+      expirationDuration
+      openViolationOnExpiration
+    }
+    ... on AlertsNrqlStaticCondition {
+      valueFunction
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_create_response.json
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_create_response.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "alertsNrqlConditionStaticCreate": {
+      "enabled": true,
+      "expiration": {
+        "closeViolationsOnExpiration": false,
+        "expirationDuration": 60,
+        "openViolationOnExpiration": false
+      },
+      "id": "11111111",
+      "name": "Test NRQL Condition",
+      "nrql": {
+        "query": "SELECT count(*) from `test:test-event`"
+      },
+      "runbookUrl": null,
+      "signal": {
+        "aggregationDelay": 120,
+        "aggregationMethod": "CADENCE",
+        "aggregationTimer": null,
+        "aggregationWindow": 60,
+        "evaluationDelay": null,
+        "fillOption": "NONE",
+        "fillValue": null,
+        "slideBy": null
+      },
+      "terms": [
+        {
+          "operator": "ABOVE_OR_EQUALS",
+          "priority": "CRITICAL",
+          "threshold": 1,
+          "thresholdDuration": 60,
+          "thresholdOccurrences": "AT_LEAST_ONCE"
+        }
+      ],
+      "valueFunction": "SINGLE_VALUE"
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_delete_error.json
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_delete_error.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "alertsConditionDelete": null
+  },
+  "errors": [
+    {
+      "extensions": {
+        "code": "BAD_USER_INPUT",
+        "errorClass": "BAD_USER_INPUT"
+      },
+      "locations": [
+        {
+          "column": 3,
+          "line": 2
+        }
+      ],
+      "message": "Not Found",
+      "path": [
+        "alertsConditionDelete"
+      ]
+    }
+  ]
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_delete_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_delete_request.txt
@@ -1,0 +1,5 @@
+mutation {
+  alertsConditionDelete(accountId:12345678 id:11111111) {
+    id
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_delete_response.json
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_delete_response.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "alertsConditionDelete": {
+      "id": "11111111"
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_list_request_part1.txt
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_list_request_part1.txt
@@ -1,0 +1,43 @@
+actor {
+  account(id:12345678) {
+    alerts {
+      nrqlConditionsSearch(cursor:"" searchCriteria:{policyId:7654321}) {
+        nextCursor
+        nrqlConditions {
+          id
+          name
+          enabled
+          runbookUrl
+          nrql {
+            query
+          }
+          signal {
+            aggregationDelay
+            aggregationMethod
+            aggregationTimer
+            aggregationWindow
+            evaluationDelay
+            fillOption
+            fillValue
+            slideBy
+          }
+          terms {
+            operator
+            priority
+            threshold
+            thresholdDuration
+            thresholdOccurrences
+          }
+          expiration {
+            closeViolationsOnExpiration
+            expirationDuration
+            openViolationOnExpiration
+          }
+          ... on AlertsNrqlStaticCondition {
+            valueFunction
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_list_request_part2.txt
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_list_request_part2.txt
@@ -1,0 +1,43 @@
+actor {
+  account(id:12345678) {
+    alerts {
+      nrqlConditionsSearch(cursor:"123456abcdeFGHIJKLMNOP==:7899999999999999ZZzZzzZ=" searchCriteria:{policyId:7654321}) {
+        nextCursor
+        nrqlConditions {
+          id
+          name
+          enabled
+          runbookUrl
+          nrql {
+            query
+          }
+          signal {
+            aggregationDelay
+            aggregationMethod
+            aggregationTimer
+            aggregationWindow
+            evaluationDelay
+            fillOption
+            fillValue
+            slideBy
+          }
+          terms {
+            operator
+            priority
+            threshold
+            thresholdDuration
+            thresholdOccurrences
+          }
+          expiration {
+            closeViolationsOnExpiration
+            expirationDuration
+            openViolationOnExpiration
+          }
+          ... on AlertsNrqlStaticCondition {
+            valueFunction
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_list_response_part1.json
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_list_response_part1.json
@@ -1,0 +1,49 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "nrqlConditionsSearch": {
+            "nextCursor": "123456abcdeFGHIJKLMNOP==:7899999999999999ZZzZzzZ=",
+            "nrqlConditions": [
+              {
+                "enabled": true,
+                "expiration": {
+                  "closeViolationsOnExpiration": true,
+                  "expirationDuration": 900,
+                  "openViolationOnExpiration": false
+                },
+                "id": "11111111",
+                "name": "Test NRQL Condition 1",
+                "nrql": {
+                  "query": "SELECT count(*) from `test1:test-event`"
+                },
+                "runbookUrl": null,
+                "signal": {
+                  "aggregationDelay": 120,
+                  "aggregationMethod": "EVENT_FLOW",
+                  "aggregationTimer": null,
+                  "aggregationWindow": 60,
+                  "evaluationDelay": null,
+                  "fillOption": "STATIC",
+                  "fillValue": 0,
+                  "slideBy": null
+                },
+                "terms": [
+                  {
+                    "operator": "BELOW",
+                    "priority": "CRITICAL",
+                    "threshold": 1,
+                    "thresholdDuration": 300,
+                    "thresholdOccurrences": "ALL"
+                  }
+                ],
+                "valueFunction": "SINGLE_VALUE"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_list_response_part2.json
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_list_response_part2.json
@@ -1,0 +1,49 @@
+{
+  "data": {
+    "actor": {
+      "account": {
+        "alerts": {
+          "nrqlConditionsSearch": {
+            "nextCursor": null,
+            "nrqlConditions": [
+              {
+                "enabled": true,
+                "expiration": {
+                  "closeViolationsOnExpiration": false,
+                  "expirationDuration": null,
+                  "openViolationOnExpiration": false
+                },
+                "id": "22222222",
+                "name": "Test NRQL Condition 2",
+                "nrql": {
+                  "query": "SELECT count(*) from `test2:test-event`"
+                },
+                "runbookUrl": null,
+                "signal": {
+                  "aggregationDelay": 120,
+                  "aggregationMethod": "EVENT_FLOW",
+                  "aggregationTimer": 240,
+                  "aggregationWindow": 60,
+                  "evaluationDelay": 60,
+                  "fillOption": "NONE",
+                  "fillValue": null,
+                  "slideBy": 30
+                },
+                "terms": [
+                  {
+                    "operator": "ABOVE_OR_EQUALS",
+                    "priority": "CRITICAL",
+                    "threshold": 1,
+                    "thresholdDuration": 60,
+                    "thresholdOccurrences": "AT_LEAST_ONCE"
+                  }
+                ],
+                "valueFunction": "SUM"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_update_error.json
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_update_error.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "alertsNrqlConditionStaticUpdate": null
+  },
+  "errors": [
+    {
+      "extensions": {
+        "code": "BAD_USER_INPUT",
+        "errorClass": "BAD_USER_INPUT"
+      },
+      "locations": [
+        {
+          "column": 3,
+          "line": 2
+        }
+      ],
+      "message": "Not Found",
+      "path": [
+        "alertsNrqlConditionStaticUpdate"
+      ]
+    }
+  ]
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_update_request.txt
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_update_request.txt
@@ -1,0 +1,36 @@
+mutation {
+  alertsNrqlConditionStaticUpdate(accountId:12345678 id:11111111 condition:{enabled:true,name:"Test NRQL Condition UPDATED",nrql:{query:"SELECT count(*) from `test:test-event`"},expiration:{closeViolationsOnExpiration:false,openViolationOnExpiration:false,expirationDuration:60},signal:{aggregationDelay:120,aggregationMethod:CADENCE,aggregationWindow:60,fillOption:NONE},terms:[{operator:ABOVE_OR_EQUALS,priority:CRITICAL,threshold:1.0,thresholdDuration:60,thresholdOccurrences:AT_LEAST_ONCE}],valueFunction:SINGLE_VALUE}) {
+    id
+    name
+    enabled
+    runbookUrl
+    nrql {
+      query
+    }
+    signal {
+      aggregationDelay
+      aggregationMethod
+      aggregationTimer
+      aggregationWindow
+      evaluationDelay
+      fillOption
+      fillValue
+      slideBy
+    }
+    terms {
+      operator
+      priority
+      threshold
+      thresholdDuration
+      thresholdOccurrences
+    }
+    expiration {
+      closeViolationsOnExpiration
+      expirationDuration
+      openViolationOnExpiration
+    }
+    ... on AlertsNrqlStaticCondition {
+      valueFunction
+    }
+  }
+}

--- a/newrelic-api-client/src/test/resources/AlertsNrqlConditions_update_response.json
+++ b/newrelic-api-client/src/test/resources/AlertsNrqlConditions_update_response.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "alertsNrqlConditionStaticUpdate": {
+      "enabled": true,
+      "expiration": {
+        "closeViolationsOnExpiration": false,
+        "expirationDuration": 60,
+        "openViolationOnExpiration": false
+      },
+      "id": "11111111",
+      "name": "Test NRQL Condition UPDATED",
+      "nrql": {
+        "query": "SELECT count(*) from `test:test-event`"
+      },
+      "runbookUrl": null,
+      "signal": {
+        "aggregationDelay": 120,
+        "aggregationMethod": "CADENCE",
+        "aggregationTimer": null,
+        "aggregationWindow": 60,
+        "evaluationDelay": null,
+        "fillOption": "NONE",
+        "fillValue": null,
+        "slideBy": null
+      },
+      "terms": [
+        {
+          "operator": "ABOVE_OR_EQUALS",
+          "priority": "CRITICAL",
+          "threshold": 1,
+          "thresholdDuration": 60,
+          "thresholdOccurrences": "AT_LEAST_ONCE"
+        }
+      ],
+      "valueFunction": "SINGLE_VALUE"
+    }
+  }
+}


### PR DESCRIPTION
NewRelic actively deprecates parts of it's REST API encouraging a shift towards GraphQL API so I wrote alternative NewRelicApi implementation with `AlertsChannelsApi`, `AlertsPoliciesApi` and `AlertsNrqlConditionsApi` using GraphQL API. See `NewRelicHybridApi` for details. 

There are some Api classes using already dead REST enspoints. I will prepare separate pull request removing them.